### PR TITLE
Path Typo Fix

### DIFF
--- a/Oracle/OracleJavaSEDK9.munki.recipe
+++ b/Oracle/OracleJavaSEDK9.munki.recipe
@@ -131,7 +131,7 @@
                 <string>%pkgroot%</string>
                 <key>installs_item_paths</key>
                 <array>
-                    <string>/Library/Java/JavaVirtualMachines/jdk%version%.jdk</string>
+                    <string>/Library/Java/JavaVirtualMachines/jdk-%version%.jdk</string>
                 </array>
                 <key>version_comparison_key</key>
                 <string>CFBundleVersion</string>


### PR DESCRIPTION
This was causing munki to install the package on every run due to the invalid path used for version comparison.