### PR TITLE
Add blocking app for Postman

### DIFF
--- a/Postman/Postman.munki.recipe
+++ b/Postman/Postman.munki.recipe
@@ -14,6 +14,10 @@
         <string>developer</string>
         <key>pkginfo</key>
         <dict>
+            <key>blocking_applications</key>
+            <array>
+                <string>Postman.app</string>
+            </array>
             <key>catalogs</key>
             <array>
                 <string>testing</string>


### PR DESCRIPTION
Since Postman is being installed from a pkg, Munki does not automatically infer blocking applications.