### PR TITLE
Remove DISABLE_CODE_SIGNATURE_VERIFICATION input variable

### DIFF
--- a/STAN4J/STAN4J.download.recipe
+++ b/STAN4J/STAN4J.download.recipe
@@ -10,8 +10,6 @@
     <dict>
         <key>NAME</key>
         <string>STAN4J</string>
-        <key>DISABLE_CODE_SIGNATURE_VERIFICATION</key>
-        <string>True</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.0</string>


### PR DESCRIPTION
There's no CodeSignatureVerifier processor in this recipe, so this input variable has no effect.