### PR TITLE
JetBrains recipe improvements

### DIFF
--- a/JetBrains/AppCode.download.recipe
+++ b/JetBrains/AppCode.download.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the current release version of AppCode. For Intel (x86_64) set ARCHITECTURE to 'mac'; for Apple silicon (arm64) use 'macM1'.</string>
+    <string>Downloads the current release version of AppCode.</string>
     <key>Identifier</key>
     <string>com.github.bnpl.autopkg.download.appcode</string>
     <key>Input</key>

--- a/JetBrains/AppCode.download.recipe
+++ b/JetBrains/AppCode.download.recipe
@@ -12,8 +12,6 @@
         <string>AppCode</string>
         <key>PROD_CODE</key>
         <string>AC</string>
-        <key>APP_NAME</key>
-        <string>AppCode</string>
         <key>CSV_REQ</key>
         <string>identifier "com.jetbrains.AppCode" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "2ZEFAR8TH3"</string>
     </dict>

--- a/JetBrains/AppCode.download.recipe
+++ b/JetBrains/AppCode.download.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the current release version of AppCode.</string>
+    <string>Downloads the current release version of AppCode. For Intel (x86_64) set ARCHITECTURE to 'mac'; for Apple silicon (arm64) use 'macM1'.</string>
     <key>Identifier</key>
     <string>com.github.bnpl.autopkg.download.appcode</string>
     <key>Input</key>

--- a/JetBrains/CLion.download.recipe
+++ b/JetBrains/CLion.download.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the current release version of CLion. For Intel (x86_64) set ARCHITECTURE to 'mac'; for Apple silicon (arm64) use 'macM1'.</string>
+    <string>Downloads the current release version of CLion.</string>
     <key>Identifier</key>
     <string>com.github.bnpl.autopkg.download.clion</string>
     <key>Input</key>

--- a/JetBrains/CLion.download.recipe
+++ b/JetBrains/CLion.download.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the current release version of CLion.</string>
+    <string>Downloads the current release version of CLion. For Intel (x86_64) set ARCHITECTURE to 'mac'; for Apple silicon (arm64) use 'macM1'.</string>
     <key>Identifier</key>
     <string>com.github.bnpl.autopkg.download.clion</string>
     <key>Input</key>

--- a/JetBrains/CLion.download.recipe
+++ b/JetBrains/CLion.download.recipe
@@ -12,8 +12,6 @@
         <string>CLion</string>
         <key>PROD_CODE</key>
         <string>CL</string>
-        <key>APP_NAME</key>
-        <string>CLion</string>
         <key>CSV_REQ</key>
         <string>identifier "com.jetbrains.CLion" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "2ZEFAR8TH3"</string>
     </dict>

--- a/JetBrains/DataGrip.download.recipe
+++ b/JetBrains/DataGrip.download.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the current release version of DataGrip.</string>
+    <string>Downloads the current release version of DataGrip. For Intel (x86_64) set ARCHITECTURE to 'mac'; for Apple silicon (arm64) use 'macM1'.</string>
     <key>Identifier</key>
     <string>com.github.bnpl.autopkg.download.datagrip</string>
     <key>Input</key>

--- a/JetBrains/DataGrip.download.recipe
+++ b/JetBrains/DataGrip.download.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the current release version of DataGrip. For Intel (x86_64) set ARCHITECTURE to 'mac'; for Apple silicon (arm64) use 'macM1'.</string>
+    <string>Downloads the current release version of DataGrip.</string>
     <key>Identifier</key>
     <string>com.github.bnpl.autopkg.download.datagrip</string>
     <key>Input</key>

--- a/JetBrains/DataGrip.download.recipe
+++ b/JetBrains/DataGrip.download.recipe
@@ -12,8 +12,6 @@
         <string>DataGrip</string>
         <key>PROD_CODE</key>
         <string>DG</string>
-        <key>APP_NAME</key>
-        <string>DataGrip</string>
         <key>CSV_REQ</key>
         <string>identifier "com.jetbrains.datagrip" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "2ZEFAR8TH3"</string>
     </dict>

--- a/JetBrains/GoLand.download.recipe
+++ b/JetBrains/GoLand.download.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the current release version of GoLand.</string>
+    <string>Downloads the current release version of GoLand. For Intel (x86_64) set ARCHITECTURE to 'mac'; for Apple silicon (arm64) use 'macM1'.</string>
     <key>Identifier</key>
     <string>com.github.bnpl.autopkg.download.goland</string>
     <key>Input</key>

--- a/JetBrains/GoLand.download.recipe
+++ b/JetBrains/GoLand.download.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the current release version of GoLand. For Intel (x86_64) set ARCHITECTURE to 'mac'; for Apple silicon (arm64) use 'macM1'.</string>
+    <string>Downloads the current release version of GoLand.</string>
     <key>Identifier</key>
     <string>com.github.bnpl.autopkg.download.goland</string>
     <key>Input</key>

--- a/JetBrains/GoLand.download.recipe
+++ b/JetBrains/GoLand.download.recipe
@@ -12,8 +12,6 @@
         <string>GoLand</string>
         <key>PROD_CODE</key>
         <string>GO</string>
-        <key>APP_NAME</key>
-        <string>GoLand</string>
         <key>CSV_REQ</key>
         <string>identifier "com.jetbrains.goland" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "2ZEFAR8TH3"</string>
     </dict>

--- a/JetBrains/IntelliJ-IDEA-CE.download.recipe
+++ b/JetBrains/IntelliJ-IDEA-CE.download.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the current release version of IntelliJ IDEA Community Edition.</string>
+    <string>Downloads the current release version of IntelliJ IDEA Community Edition. For Intel (x86_64) set ARCHITECTURE to 'mac'; for Apple silicon (arm64) use 'macM1'.</string>
     <key>Identifier</key>
     <string>com.github.bnpl.autopkg.download.intellijideace</string>
     <key>Input</key>

--- a/JetBrains/IntelliJ-IDEA-CE.download.recipe
+++ b/JetBrains/IntelliJ-IDEA-CE.download.recipe
@@ -12,8 +12,6 @@
         <string>IntelliJ IDEA Community Edition</string>
         <key>PROD_CODE</key>
         <string>IIC</string>
-        <key>APP_NAME</key>
-        <string>IntelliJ IDEA CE</string>
         <key>CSV_REQ</key>
         <string>identifier "com.jetbrains.intellij.ce" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "2ZEFAR8TH3"</string>
     </dict>

--- a/JetBrains/IntelliJ-IDEA-CE.download.recipe
+++ b/JetBrains/IntelliJ-IDEA-CE.download.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the current release version of IntelliJ IDEA Community Edition. For Intel (x86_64) set ARCHITECTURE to 'mac'; for Apple silicon (arm64) use 'macM1'.</string>
+    <string>Downloads the current release version of IntelliJ IDEA Community Edition.</string>
     <key>Identifier</key>
     <string>com.github.bnpl.autopkg.download.intellijideace</string>
     <key>Input</key>

--- a/JetBrains/IntelliJ-IDEA-UE.download.recipe
+++ b/JetBrains/IntelliJ-IDEA-UE.download.recipe
@@ -12,8 +12,6 @@
         <string>IntelliJ IDEA Ultimate Edition</string>
         <key>PROD_CODE</key>
         <string>IIU</string>
-        <key>APP_NAME</key>
-        <string>IntelliJ IDEA</string>
         <key>CSV_REQ</key>
         <string>identifier "com.jetbrains.intellij" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "2ZEFAR8TH3"</string>
     </dict>

--- a/JetBrains/IntelliJ-IDEA-UE.download.recipe
+++ b/JetBrains/IntelliJ-IDEA-UE.download.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the current release version of IntelliJ IDEA Ultimate Edition. For Intel (x86_64) set ARCHITECTURE to 'mac'; for Apple silicon (arm64) use 'macM1'.</string>
+    <string>Downloads the current release version of IntelliJ IDEA Ultimate Edition.</string>
     <key>Identifier</key>
     <string>com.github.bnpl.autopkg.download.intellijideaue</string>
     <key>Input</key>

--- a/JetBrains/IntelliJ-IDEA-UE.download.recipe
+++ b/JetBrains/IntelliJ-IDEA-UE.download.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the current release version of IntelliJ IDEA Ultimate Edition.</string>
+    <string>Downloads the current release version of IntelliJ IDEA Ultimate Edition. For Intel (x86_64) set ARCHITECTURE to 'mac'; for Apple silicon (arm64) use 'macM1'.</string>
     <key>Identifier</key>
     <string>com.github.bnpl.autopkg.download.intellijideaue</string>
     <key>Input</key>

--- a/JetBrains/JetBrains.download.recipe
+++ b/JetBrains/JetBrains.download.recipe
@@ -3,11 +3,13 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the current release version of JetBrains product.</string>
+    <string>Downloads the current release version of JetBrains product. For Intel (x86_64) set ARCHITECTURE to 'mac'; for Apple silicon (arm64) use 'macM1'.</string>
     <key>Identifier</key>
     <string>com.github.bnpl.autopkg.download.jetbrains</string>
     <key>Input</key>
     <dict>
+        <key>ARCHITECTURE</key>
+        <string>mac</string>
         <key>NAME</key>
         <string>JetBrainsProductDownload</string>
         <key>PROD_CODE</key>
@@ -25,7 +27,7 @@
                 <key>url</key>
                 <string>https://data.services.jetbrains.com/products/releases?code=%PROD_CODE%&amp;latest=true&amp;type=release</string>
                 <key>re_pattern</key>
-                <string>"mac":{"link":"(https://download.jetbrains.com/.*?.dmg)"</string>
+                <string>"%ARCHITECTURE%":{"link":"(https://download.jetbrains.com/.*?.dmg)"</string>
                 <key>request_headers</key>
                 <dict>
                     <key>user-agent</key>
@@ -44,11 +46,27 @@
         </dict>
         <dict>
             <key>Processor</key>
-            <string>AppDmgVersioner</string>
+            <string>FileFinder</string>
             <key>Arguments</key>
             <dict>
-                <key>dmg_path</key>
-                <string>%pathname%</string>
+                <key>pattern</key>
+                <string>%pathname%/*.app</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>PlistReader</string>
+            <key>Arguments</key>
+            <dict>
+                <key>info_path</key>
+                <string>%pathname%/%dmg_found_filename%</string>
+                <key>plist_keys</key>
+                <dict>
+                    <key>CFBundleShortVersionString</key>
+                    <string>version</string>
+                    <key>LSMinimumSystemVersion</key>
+                    <string>min_os_vers</string>
+                </dict>
             </dict>
         </dict>
         <dict>
@@ -57,9 +75,11 @@
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%pathname%/%APP_NAME%.app</string>
+                <string>%pathname%/%dmg_found_filename%</string>
                 <key>requirement</key>
                 <string>%CSV_REQ%</string>
+                <key>strict_verification</key>
+                <true/>
             </dict>
         </dict>
         <dict>

--- a/JetBrains/JetBrains.download.recipe
+++ b/JetBrains/JetBrains.download.recipe
@@ -3,13 +3,11 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the current release version of JetBrains product. For Intel (x86_64) set ARCHITECTURE to 'mac'; for Apple silicon (arm64) use 'macM1'.</string>
+    <string>Downloads the current release version of JetBrains product.</string>
     <key>Identifier</key>
     <string>com.github.bnpl.autopkg.download.jetbrains</string>
     <key>Input</key>
     <dict>
-        <key>ARCHITECTURE</key>
-        <string>mac</string>
         <key>NAME</key>
         <string>JetBrainsProductDownload</string>
         <key>PROD_CODE</key>
@@ -27,7 +25,7 @@
                 <key>url</key>
                 <string>https://data.services.jetbrains.com/products/releases?code=%PROD_CODE%&amp;latest=true&amp;type=release</string>
                 <key>re_pattern</key>
-                <string>"%ARCHITECTURE%":{"link":"(https://download.jetbrains.com/.*?.dmg)"</string>
+                <string>"mac":{"link":"(https://download.jetbrains.com/.*?.dmg)"</string>
                 <key>request_headers</key>
                 <dict>
                     <key>user-agent</key>

--- a/JetBrains/PhpStorm.download.recipe
+++ b/JetBrains/PhpStorm.download.recipe
@@ -12,8 +12,6 @@
         <string>PhpStorm</string>
         <key>PROD_CODE</key>
         <string>PS</string>
-        <key>APP_NAME</key>
-        <string>PhpStorm</string>
         <key>CSV_REQ</key>
         <string>identifier "com.jetbrains.PhpStorm" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "2ZEFAR8TH3"</string>
     </dict>

--- a/JetBrains/PhpStorm.download.recipe
+++ b/JetBrains/PhpStorm.download.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the current release version of PhpStorm.</string>
+    <string>Downloads the current release version of PhpStorm. For Intel (x86_64) set ARCHITECTURE to 'mac'; for Apple silicon (arm64) use 'macM1'.</string>
     <key>Identifier</key>
     <string>com.github.bnpl.autopkg.download.phpstorm</string>
     <key>Input</key>

--- a/JetBrains/PhpStorm.download.recipe
+++ b/JetBrains/PhpStorm.download.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the current release version of PhpStorm. For Intel (x86_64) set ARCHITECTURE to 'mac'; for Apple silicon (arm64) use 'macM1'.</string>
+    <string>Downloads the current release version of PhpStorm.</string>
     <key>Identifier</key>
     <string>com.github.bnpl.autopkg.download.phpstorm</string>
     <key>Input</key>

--- a/JetBrains/PyCharm-CE.download.recipe
+++ b/JetBrains/PyCharm-CE.download.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the current release version of PyCharm Community Edition. For Intel (x86_64) set ARCHITECTURE to 'mac'; for Apple silicon (arm64) use 'macM1'.</string>
+    <string>Downloads the current release version of PyCharm Community Edition.</string>
     <key>Identifier</key>
     <string>com.github.bnpl.autopkg.download.pycharmce</string>
     <key>Input</key>

--- a/JetBrains/PyCharm-CE.download.recipe
+++ b/JetBrains/PyCharm-CE.download.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the current release version of PyCharm Community Edition.</string>
+    <string>Downloads the current release version of PyCharm Community Edition. For Intel (x86_64) set ARCHITECTURE to 'mac'; for Apple silicon (arm64) use 'macM1'.</string>
     <key>Identifier</key>
     <string>com.github.bnpl.autopkg.download.pycharmce</string>
     <key>Input</key>

--- a/JetBrains/PyCharm-CE.download.recipe
+++ b/JetBrains/PyCharm-CE.download.recipe
@@ -12,8 +12,6 @@
         <string>PyCharm Community Edition</string>
         <key>PROD_CODE</key>
         <string>PCC</string>
-        <key>APP_NAME</key>
-        <string>PyCharm CE</string>
         <key>CSV_REQ</key>
         <string>identifier "com.jetbrains.pycharm" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "2ZEFAR8TH3"</string>
     </dict>

--- a/JetBrains/PyCharm-Edu.download.recipe
+++ b/JetBrains/PyCharm-Edu.download.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the current release version of PyCharm Edu. For Intel (x86_64) set ARCHITECTURE to 'mac'; for Apple silicon (arm64) use 'macM1'.</string>
+    <string>Downloads the current release version of PyCharm Edu.</string>
     <key>Identifier</key>
     <string>com.github.bnpl.autopkg.download.pycharmedu</string>
     <key>Input</key>

--- a/JetBrains/PyCharm-Edu.download.recipe
+++ b/JetBrains/PyCharm-Edu.download.recipe
@@ -12,8 +12,6 @@
         <string>PyCharm Edu</string>
         <key>PROD_CODE</key>
         <string>PCE</string>
-        <key>APP_NAME</key>
-        <string>PyCharm Edu</string>
         <key>CSV_REQ</key>
         <string>identifier "com.jetbrains.pycharm" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "2ZEFAR8TH3"</string>
     </dict>

--- a/JetBrains/PyCharm-Edu.download.recipe
+++ b/JetBrains/PyCharm-Edu.download.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the current release version of PyCharm Edu.</string>
+    <string>Downloads the current release version of PyCharm Edu. For Intel (x86_64) set ARCHITECTURE to 'mac'; for Apple silicon (arm64) use 'macM1'.</string>
     <key>Identifier</key>
     <string>com.github.bnpl.autopkg.download.pycharmedu</string>
     <key>Input</key>

--- a/JetBrains/PyCharm-PE.download.recipe
+++ b/JetBrains/PyCharm-PE.download.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the current release version of PyCharm Professional Edition.</string>
+    <string>Downloads the current release version of PyCharm Professional Edition. For Intel (x86_64) set ARCHITECTURE to 'mac'; for Apple silicon (arm64) use 'macM1'.</string>
     <key>Identifier</key>
     <string>com.github.bnpl.autopkg.download.pycharmpe</string>
     <key>Input</key>

--- a/JetBrains/PyCharm-PE.download.recipe
+++ b/JetBrains/PyCharm-PE.download.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the current release version of PyCharm Professional Edition. For Intel (x86_64) set ARCHITECTURE to 'mac'; for Apple silicon (arm64) use 'macM1'.</string>
+    <string>Downloads the current release version of PyCharm Professional Edition.</string>
     <key>Identifier</key>
     <string>com.github.bnpl.autopkg.download.pycharmpe</string>
     <key>Input</key>

--- a/JetBrains/PyCharm-PE.download.recipe
+++ b/JetBrains/PyCharm-PE.download.recipe
@@ -12,8 +12,6 @@
         <string>PyCharm Professional Edition</string>
         <key>PROD_CODE</key>
         <string>PCP</string>
-        <key>APP_NAME</key>
-        <string>PyCharm</string>
         <key>CSV_REQ</key>
         <string>identifier "com.jetbrains.pycharm" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "2ZEFAR8TH3"</string>
     </dict>

--- a/JetBrains/Rider.download.recipe
+++ b/JetBrains/Rider.download.recipe
@@ -12,8 +12,6 @@
         <string>Rider</string>
         <key>PROD_CODE</key>
         <string>RD</string>
-        <key>APP_NAME</key>
-        <string>Rider</string>
         <key>CSV_REQ</key>
         <string>identifier "com.jetbrains.rider" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "2ZEFAR8TH3"</string>
     </dict>

--- a/JetBrains/Rider.download.recipe
+++ b/JetBrains/Rider.download.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the current release version of Rider.</string>
+    <string>Downloads the current release version of Rider. For Intel (x86_64) set ARCHITECTURE to 'mac'; for Apple silicon (arm64) use 'macM1'.</string>
     <key>Identifier</key>
     <string>com.github.bnpl.autopkg.download.rider</string>
     <key>Input</key>

--- a/JetBrains/Rider.download.recipe
+++ b/JetBrains/Rider.download.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the current release version of Rider. For Intel (x86_64) set ARCHITECTURE to 'mac'; for Apple silicon (arm64) use 'macM1'.</string>
+    <string>Downloads the current release version of Rider.</string>
     <key>Identifier</key>
     <string>com.github.bnpl.autopkg.download.rider</string>
     <key>Input</key>

--- a/JetBrains/RubyMine.download.recipe
+++ b/JetBrains/RubyMine.download.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the current release version of RubyMine.</string>
+    <string>Downloads the current release version of RubyMine. For Intel (x86_64) set ARCHITECTURE to 'mac'; for Apple silicon (arm64) use 'macM1'.</string>
     <key>Identifier</key>
     <string>com.github.bnpl.autopkg.download.rubymine</string>
     <key>Input</key>

--- a/JetBrains/RubyMine.download.recipe
+++ b/JetBrains/RubyMine.download.recipe
@@ -12,8 +12,6 @@
         <string>RubyMine</string>
         <key>PROD_CODE</key>
         <string>RM</string>
-        <key>APP_NAME</key>
-        <string>RubyMine</string>
         <key>CSV_REQ</key>
         <string>identifier "com.jetbrains.rubymine" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "2ZEFAR8TH3"</string>
     </dict>

--- a/JetBrains/RubyMine.download.recipe
+++ b/JetBrains/RubyMine.download.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the current release version of RubyMine. For Intel (x86_64) set ARCHITECTURE to 'mac'; for Apple silicon (arm64) use 'macM1'.</string>
+    <string>Downloads the current release version of RubyMine.</string>
     <key>Identifier</key>
     <string>com.github.bnpl.autopkg.download.rubymine</string>
     <key>Input</key>

--- a/JetBrains/WebStorm.download.recipe
+++ b/JetBrains/WebStorm.download.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the current release version of WebStorm. For Intel (x86_64) set ARCHITECTURE to 'mac'; for Apple silicon (arm64) use 'macM1'.</string>
+    <string>Downloads the current release version of WebStorm.</string>
     <key>Identifier</key>
     <string>com.github.bnpl.autopkg.download.webstorm</string>
     <key>Input</key>

--- a/JetBrains/WebStorm.download.recipe
+++ b/JetBrains/WebStorm.download.recipe
@@ -12,8 +12,6 @@
         <string>WebStorm</string>
         <key>PROD_CODE</key>
         <string>WS</string>
-        <key>APP_NAME</key>
-        <string>WebStorm</string>
         <key>CSV_REQ</key>
         <string>identifier "com.jetbrains.WebStorm" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "2ZEFAR8TH3"</string>
     </dict>

--- a/JetBrains/WebStorm.download.recipe
+++ b/JetBrains/WebStorm.download.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the current release version of WebStorm.</string>
+    <string>Downloads the current release version of WebStorm. For Intel (x86_64) set ARCHITECTURE to 'mac'; for Apple silicon (arm64) use 'macM1'.</string>
     <key>Identifier</key>
     <string>com.github.bnpl.autopkg.download.webstorm</string>
     <key>Input</key>


### PR DESCRIPTION
~The core intention of this change was to add the ability for admins to specify for a JetBrains item whether or not they wanted an Intel or Apple silicon version.  However, I added some additional improvements as well.~

~Given that creating an override will add input variables into the resulting recipe, I opted not to add to every single JetBrains app .download or .munki recipe and only added to description.  But if you want to be more explicit that's totally fine.  That said, adding this new `ARCHITECTURE` input variable would cause existing overrides to break since updating trust will not update the input vars.  There may be a better way to handle that piece.~

Summary of changes:

~- Add ARCHITECTURE Input variable to allow specifying 'mac' for Intel-based distros or 'macM1' for Apple Silicon~
- Replace AppDmgVersioner with PlistReader to gather both the version (%version%) and the minimum supported macOS version (%min_os_vers%)
- Add FileFinder processor to get the explicit app path for PlistReader and CodeSignatureVerifier
- Add strict_verification to CodeSignatureVerifier

Output from successful run with `PyCharm-PE.munki.recipe` ~when specified for M1~:
```
autopkg run -vv ./PyCharm-PE.munki.recipe                                    16:17:55
Processing ./PyCharm-PE.munki.recipe...
WARNING: ./PyCharm-PE.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': '"macM1":{"link":"(https://download.jetbrains.com/.*?.dmg)"',
           'request_headers': {'user-agent': 'Mozilla/5.0 (Macintosh; Intel '
                                             'Mac OS X 10.11; rv:46.0) '
                                             'Gecko/20100101 Firefox/46.0'},
           'url': 'https://data.services.jetbrains.com/products/releases?code=PCP&latest=true&type=release'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (match): https://download.jetbrains.com/python/pycharm-professional-2021.3.2.dmg
{'Output': {'match': 'https://download.jetbrains.com/python/pycharm-professional-2021.3.2-aarch64.dmg'}}
URLDownloader
{'Input': {'request_headers': {'user-agent': 'Mozilla/5.0 (Macintosh; Intel '
                                             'Mac OS X 10.11; rv:46.0) '
                                             'Gecko/20100101 Firefox/46.0'},
           'url': 'https://download.jetbrains.com/python/pycharm-professional-2021.3.2-aarch64.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Fri, 28 Jan 2022 18:10:10 GMT
URLDownloader: Storing new ETag header: "4ea7211ca0f9ef60891d9851522afc03-75"
URLDownloader: Downloaded /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.pycharmpe/downloads/pycharm-professional-2021.3.2-aarch64.dmg
{'Output': {'download_changed': True,
            'etag': '"4ea7211ca0f9ef60891d9851522afc03-75"',
            'last_modified': 'Fri, 28 Jan 2022 18:10:10 GMT',
            'pathname': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.pycharmpe/downloads/pycharm-professional-2021.3.2-aarch64.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.pycharmpe/downloads/pycharm-professional-2021.3.2-aarch64.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
FileFinder
{'Input': {'pattern': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.pycharmpe/downloads/pycharm-professional-2021.3.2-aarch64.dmg/*.app'}}
FileFinder: No value supplied for find_method, setting default value of: glob
FileFinder: Mounted disk image /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.pycharmpe/downloads/pycharm-professional-2021.3.2-aarch64.dmg
FileFinder: Found file match: '/private/tmp/dmg.dyCiJB/PyCharm.app' from globbed '/private/tmp/dmg.dyCiJB/*.app'
FileFinder: DMG-relative file match: 'PyCharm.app'
{'Output': {'dmg_found_filename': 'PyCharm.app',
            'found_filename': '/private/tmp/dmg.dyCiJB/PyCharm.app'}}
PlistReader
{'Input': {'info_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.pycharmpe/downloads/pycharm-professional-2021.3.2-aarch64.dmg/PyCharm.app',
           'plist_keys': {'CFBundleShortVersionString': 'version',
                          'LSMinimumSystemVersion': 'min_os_vers'}}}
PlistReader: Mounted disk image /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.pycharmpe/downloads/pycharm-professional-2021.3.2-aarch64.dmg
PlistReader: Reading: /private/tmp/dmg.fwZ0cY/PyCharm.app/Contents/Info.plist
PlistReader: Assigning value of '2021.3.2' to output variable 'version'
PlistReader: Assigning value of '10.8' to output variable 'min_os_vers'
{'Output': {'plist_reader_output_variables': {'min_os_vers': '10.8',
                                              'version': '2021.3.2'}}}
CodeSignatureVerifier
{'Input': {'input_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.pycharmpe/downloads/pycharm-professional-2021.3.2-aarch64.dmg/PyCharm.app',
           'requirement': 'identifier "com.jetbrains.pycharm" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"2ZEFAR8TH3"',
           'strict_verification': True}}
CodeSignatureVerifier: Mounted disk image /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.pycharmpe/downloads/pycharm-professional-2021.3.2-aarch64.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification enabled...
CodeSignatureVerifier: /private/tmp/dmg.3iNjFM/PyCharm.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.3iNjFM/PyCharm.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.3iNjFM/PyCharm.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'munkiimport_appname': 'PyCharm.app',
           'pkg_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.pycharmpe/downloads/pycharm-professional-2021.3.2-aarch64.dmg',
           'pkginfo': {'catalogs': ['testing'],
                       'category': 'Developer Tools',
                       'description': 'Python IDE for professional developers\n'
                                      '\n'
                                      'https://www.jetbrains.com/pycharm',
                       'developer': 'JetBrains',
                       'display_name': 'PyCharm Professional Edition',
                       'name': 'PyCharm Professional Edition',
                       'unattended_install': True,
                       'unattended_uninstall': True,
                       'uninstallable': True},
           'repo_subdirectory': 'apps/jetbrains'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/jetbrains/PyCharm Professional Edition-2021.3.2.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/jetbrains/pycharm-professional-2021.3.2.dmg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'PyCharm '
                                                               'Professional '
                                                               'Edition',
                                                       'pkg_repo_path': 'apps/jetbrains/pycharm-professional-2021.3.2.dmg',
                                                       'pkginfo_path': 'apps/jetbrains/PyCharm '
                                                                       'Professional '
                                                                       'Edition-2021.3.2.plist',
                                                       'version': '2021.3.2'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'autopkgadmin',
                                         'creation_date': datetime.datetime(2022, 2, 9, 21, 18, 55),
                                         'munki_version': '5.6.2.4398',
                                         'os_version': '12.1'},
                           'autoremove': False,
                           'catalogs': ['testing'],
                           'category': 'Developer Tools',
                           'description': 'Python IDE for professional '
                                          'developers\n'
                                          '\n'
                                          'https://www.jetbrains.com/pycharm',
                           'developer': 'JetBrains',
                           'display_name': 'PyCharm Professional Edition',
                           'installer_item_hash': '188b998660e7cfb7ac1364c818c008a5608ab2aeb17c6cc19d1d9dda547d3775',
                           'installer_item_location': 'apps/jetbrains/pycharm-professional-2021.3.2.dmg',
                           'installer_item_size': 612520,
                           'installer_type': 'copy_from_dmg',
                           'installs': [{'CFBundleIdentifier': 'com.jetbrains.pycharm',
                                         'CFBundleName': 'PyCharm',
                                         'CFBundleShortVersionString': '2021.3.2',
                                         'CFBundleVersion': 'PY-213.6777.50',
                                         'minosversion': '10.8',
                                         'path': '/Applications/PyCharm.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'items_to_copy': [{'destination_path': '/Applications',
                                              'source_item': 'PyCharm.app'}],
                           'minimum_os_version': '10.8',
                           'name': 'PyCharm Professional Edition',
                           'unattended_install': True,
                           'unattended_uninstall': True,
                           'uninstall_method': 'remove_copied_items',
                           'uninstallable': True,
                           'version': '2021.3.2'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/apps/jetbrains/pycharm-professional-2021.3.2.dmg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/apps/jetbrains/PyCharm '
                                 'Professional Edition-2021.3.2.plist'}}
Receipt written to /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.pycharmpe/receipts/PyCharm-PE.munki-receipt-20220209-161856.plist

The following new items were downloaded:
    Download Path                                                                                                         
    -------------                                                                                                         
    /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.pycharmpe/downloads/pycharm-professional-2021.3.2.dmg  

The following new items were imported into Munki:
    Name                          Version   Catalogs  Pkginfo Path                                                Pkg Repo Path                                     Icon Repo Path  
    ----                          -------   --------  ------------                                                -------------                                     --------------  
    PyCharm Professional Edition  2021.3.2  testing   apps/jetbrains/PyCharm Professional Edition-2021.3.2.plist  apps/jetbrains/pycharm-professional-2021.3.2.dmg     
```