### PR TITLE
Update RPiImager.munki.recipe

### DIFF
--- a/RPiImager/RPiImager.munki.recipe
+++ b/RPiImager/RPiImager.munki.recipe
@@ -45,6 +45,34 @@
         <dict>
             <key>Arguments</key>
             <dict>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/Applications/Raspberry Pi Imager.app</string>
+                <key>source_path</key>
+                <string>%RECIPE_CACHE_DIR%/downloads/Raspberry.Pi.Imager.%version%.dmg/Raspberry Pi Imager.app</string>
+            </dict>
+            <key>Processor</key>
+            <string>Copier</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>faux_root</key>
+                <string>%RECIPE_CACHE_DIR%</string>
+                <key>installs_item_paths</key>
+                <array>
+                    <string>/Applications/Raspberry Pi Imager.app</string>
+                </array>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiInstallsItemsCreator</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
                 <key>pkg_path</key>
                 <string>%RECIPE_CACHE_DIR%/Raspberry Pi Imager-%version%.pkg</string>
                 <key>repo_subdirectory</key>
@@ -52,6 +80,17 @@
             </dict>
             <key>Processor</key>
             <string>MunkiImporter</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>path_list</key>
+                <array>
+                    <string>%RECIPE_CACHE_DIR%/Applications</string>
+                </array>
+            </dict>
+            <key>Processor</key>
+            <string>PathDeleter</string>
         </dict>
     </array>
 </dict>


### PR DESCRIPTION
Hi @barteklk 

This PR adds in the creation of an Installs Array, and then tidies up after itself.

Output from a successful run 

```
autopkg run -v /Users/paul/Documents/GitHub/AutoPkg\ Repos/bnpl-recipes/RPiImager/RPiImager.munki.recipe 
Processing /Users/paul/Documents/GitHub/AutoPkg Repos/bnpl-recipes/RPiImager/RPiImager.munki.recipe...
WARNING: /Users/paul/Documents/GitHub/AutoPkg Repos/bnpl-recipes/RPiImager/RPiImager.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
GitHubReleasesInfoProvider: Matched regex '.*\.dmg' among asset(s): imager-1.7.4.exe, Raspberry.Pi.Imager.1.7.4.dmg, Raspberry.Pi.Imager.1.7.4.UNTESTED.UNIVERSAL.BUILD.dmg, rpi-imager-dbgsym_1.7.4_amd64.ddeb, rpi-imager_1.7.4_amd64.deb
GitHubReleasesInfoProvider: Selected asset 'Raspberry.Pi.Imager.1.7.4.dmg' from release 'v1.7.4 release'
URLDownloader
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/paul/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.rpiimager/downloads/Raspberry.Pi.Imager.1.7.4.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/paul/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.rpiimager/downloads/Raspberry.Pi.Imager.1.7.4.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.gZCdvn/Raspberry Pi Imager.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.gZCdvn/Raspberry Pi Imager.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.gZCdvn/Raspberry Pi Imager.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
AppPkgCreator
AppPkgCreator: Mounted disk image /Users/paul/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.rpiimager/downloads/Raspberry.Pi.Imager.1.7.4.dmg
AppPkgCreator: Using path '/private/tmp/dmg.HePDlm/Raspberry Pi Imager.app' matched from globbed '/private/tmp/dmg.HePDlm/*.app'.
AppPkgCreator: BundleID: org.raspberrypi.imagingutility
AppPkgCreator: Package already exists at path /Users/paul/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.rpiimager/Raspberry Pi Imager-1.7.4.pkg.
AppPkgCreator: Existing package matches version and identifier, not building.
Copier
Copier: Mounted disk image /Users/paul/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.rpiimager/downloads/Raspberry.Pi.Imager.1.7.4.dmg
Copier: Copied /private/tmp/dmg.5d3S2S/Raspberry Pi Imager.app to /Users/paul/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.rpiimager/Applications/Raspberry Pi Imager.app
MunkiInstallsItemsCreator
MunkiInstallsItemsCreator: Created installs item for /Applications/Raspberry Pi Imager.app
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'installs': [{'CFBundleIdentifier': 'org.raspberrypi.imagingutility', 'CFBundleName': 'Raspberry Pi Imager', 'CFBundleShortVersionString': '1.7.4', 'CFBundleVersion': '1.7.4', 'path': '/Applications/Raspberry Pi Imager.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}]} into pkginfo
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/RPiImager-1.7.4__4.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/Raspberry Pi Imager-1.7.4__4.pkg
PathDeleter
PathDeleter: Deleted /Users/paul/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.rpiimager/Applications
Receipt written to /Users/paul/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.rpiimager/receipts/RPiImager.munki-receipt-20230509-124450.plist

The following new items were imported into Munki:
    Name       Version  Catalogs  Pkginfo Path                   Pkg Repo Path                          Icon Repo Path  
    ----       -------  --------  ------------                   -------------                          --------------  
    RPiImager  1.7.4    testing   apps/RPiImager-1.7.4__4.plist  apps/Raspberry Pi Imager-1.7.4__4.pkg
```