### PR TITLE
Update rpiimager Munki Recipe

### DIFF
--- a/RPiImager/RPiImager.munki.recipe
+++ b/RPiImager/RPiImager.munki.recipe
@@ -48,7 +48,7 @@
                 <key>destination_path</key>
                 <string>%RECIPE_CACHE_DIR%/Applications/Raspberry Pi Imager.app</string>
                 <key>source_path</key>
-                <string>%RECIPE_CACHE_DIR%/downloads/Raspberry.Pi.Imager.%version%.dmg/Raspberry Pi Imager.app</string>
+                <string>%RECIPE_CACHE_DIR%/downloads/Raspberry.Pi.Imager.%version%-UNIVERSAL-BUILD.dmg/Raspberry Pi Imager.app</string>
             </dict>
             <key>Processor</key>
             <string>Copier</string>

--- a/RPiImager/RPiImager.munki.recipe
+++ b/RPiImager/RPiImager.munki.recipe
@@ -45,6 +45,34 @@
         <dict>
             <key>Arguments</key>
             <dict>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/Applications/Raspberry Pi Imager.app</string>
+                <key>source_path</key>
+                <string>%RECIPE_CACHE_DIR%/downloads/Raspberry.Pi.Imager.%version%.dmg/Raspberry Pi Imager.app</string>
+            </dict>
+            <key>Processor</key>
+            <string>Copier</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>faux_root</key>
+                <string>%RECIPE_CACHE_DIR%</string>
+                <key>installs_item_paths</key>
+                <array>
+                    <string>/Applications/Raspberry Pi Imager.app</string>
+                </array>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiInstallsItemsCreator</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
                 <key>pkg_path</key>
                 <string>%RECIPE_CACHE_DIR%/Raspberry Pi Imager-%version%.pkg</string>
                 <key>repo_subdirectory</key>
@@ -52,6 +80,17 @@
             </dict>
             <key>Processor</key>
             <string>MunkiImporter</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>path_list</key>
+                <array>
+                    <string>%RECIPE_CACHE_DIR%/Applications</string>
+                </array>
+            </dict>
+            <key>Processor</key>
+            <string>PathDeleter</string>
         </dict>
     </array>
 </dict>


### PR DESCRIPTION
Hi, @barteklk 

This PR has an updated `source_path` for the copier processor. 

Output from a successful -vv run 
```
autopkg run -vv /Users/paul.cossey/Documents/GitHub/AutoPkg\ Repos/bnpl-recipes/RPiImager/RPiImager.munki.recipe 
Looking for com.github.bnpl.autopkg.pkg.rpiimager...
Did not find com.github.bnpl.autopkg.pkg.rpiimager in recipe map
Rebuilding recipe map with current working directories...
Looking for com.github.bnpl.autopkg.pkg.rpiimager...
Found com.github.bnpl.autopkg.pkg.rpiimager in recipe map
Looking for com.github.bnpl.autopkg.download.rpiimager...
Found com.github.bnpl.autopkg.download.rpiimager in recipe map
**load_recipe time: 0.005241333001322346
Processing /Users/paul.cossey/Documents/GitHub/AutoPkg Repos/bnpl-recipes/RPiImager/RPiImager.munki.recipe...
WARNING: /Users/paul.cossey/Documents/GitHub/AutoPkg Repos/bnpl-recipes/RPiImager/RPiImager.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
{'Input': {'asset_regex': '.*\\.dmg', 'github_repo': 'raspberrypi/rpi-imager'}}
WARNING: This is an unathenticated Github session, some API features may not work
GitHubReleasesInfoProvider: Matched regex '.*\.dmg' among asset(s): Raspberry.Pi.Imager.1.8.3-UNIVERSAL-BUILD.dmg
GitHubReleasesInfoProvider: Selected asset 'Raspberry.Pi.Imager.1.8.3-UNIVERSAL-BUILD.dmg' from tag 'v1.8.3' at url https://github.com/raspberrypi/rpi-imager/releases/download/v1.8.3/Raspberry.Pi.Imager.1.8.3-UNIVERSAL-BUILD.dmg
{'Output': {'asset_created_at': '2023-11-16T19:19:02Z',
            'asset_url': 'https://api.github.com/repos/raspberrypi/rpi-imager/releases/assets/135906989',
            'release_notes': '  * Home: Device filtering reworked to download '
                             'OS list eagerly\r\n'
                             "  * OS List: Fixed 'Recommended' tag "
                             'annotation\r\n'
                             '  * i18n: Added zh-TW Traditional Chinese '
                             'translation\r\n'
                             '  * i18n: Updated Korean, German, Ukranian, '
                             'translations\r\n'
                             '  * build: Linux: Fix libdrm dependency '
                             'requirement on non-embedded\r\n'
                             '                  build.\r\n'
                             '  * Common: Disable QML caching entirely\r\n'
                             '  * OS customisation: Allow use if only '
                             'cloudinit payload available\r\n'
                             "  * OS customisation: Allow empty PSK for 'Open' "
                             'WiFi networks.\r\n'
                             '  * OS List: Use ImageList v4 URL\r\n'
                             '\r\n'
                             '===\r\n'
                             '\r\n'
                             '**System requirements**\r\n'
                             '\r\n'
                             'Minimum operating system version needed:\r\n'
                             '\r\n'
                             '* Windows 7\r\n'
                             '* Mac OS X 10.15\r\n'
                             '* Ubuntu 22.04',
            'url': 'https://github.com/raspberrypi/rpi-imager/releases/download/v1.8.3/Raspberry.Pi.Imager.1.8.3-UNIVERSAL-BUILD.dmg',
            'version': '1.8.3'}}
URLDownloader
{'Input': {'url': 'https://github.com/raspberrypi/rpi-imager/releases/download/v1.8.3/Raspberry.Pi.Imager.1.8.3-UNIVERSAL-BUILD.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/paul.cossey/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.rpiimager/downloads/Raspberry.Pi.Imager.1.8.3-UNIVERSAL-BUILD.dmg
{'Output': {'pathname': '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.rpiimager/downloads/Raspberry.Pi.Imager.1.8.3-UNIVERSAL-BUILD.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.rpiimager/downloads/Raspberry.Pi.Imager.1.8.3-UNIVERSAL-BUILD.dmg/Raspberry '
                         'Pi Imager.app',
           'requirement': 'identifier "org.raspberrypi.imagingutility" and '
                          'anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'WYH7G79LM6'}}
CodeSignatureVerifier: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.rpiimager/downloads/Raspberry.Pi.Imager.1.8.3-UNIVERSAL-BUILD.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.n4xx9D/Raspberry Pi Imager.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.n4xx9D/Raspberry Pi Imager.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.n4xx9D/Raspberry Pi Imager.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {'version': '1.8.3'}}
AppPkgCreator: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.rpiimager/downloads/Raspberry.Pi.Imager.1.8.3-UNIVERSAL-BUILD.dmg
AppPkgCreator: Using path '/private/tmp/dmg.t0FXC1/Raspberry Pi Imager.app' matched from globbed '/private/tmp/dmg.t0FXC1/*.app'.
AppPkgCreator: BundleID: org.raspberrypi.imagingutility
AppPkgCreator: Package already exists at path /Users/paul.cossey/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.rpiimager/Raspberry Pi Imager-1.8.3.pkg.
AppPkgCreator: Existing package matches version and identifier, not building.
{'Output': {'version': '1.8.3'}}
Copier
{'Input': {'destination_path': '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.rpiimager/Applications/Raspberry '
                               'Pi Imager.app',
           'source_path': '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.rpiimager/downloads/Raspberry.Pi.Imager.1.8.3-UNIVERSAL-BUILD.dmg/Raspberry '
                          'Pi Imager.app'}}
Copier: Parsed dmg results: dmg_path: /Users/paul.cossey/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.rpiimager/downloads/Raspberry.Pi.Imager.1.8.3-UNIVERSAL-BUILD.dmg, dmg: .dmg/, dmg_source_path: Raspberry Pi Imager.app
Copier: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.rpiimager/downloads/Raspberry.Pi.Imager.1.8.3-UNIVERSAL-BUILD.dmg
Copier: Copied /private/tmp/dmg.sRU8Tv/Raspberry Pi Imager.app to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.rpiimager/Applications/Raspberry Pi Imager.app
{'Output': {}}
MunkiInstallsItemsCreator
{'Input': {'faux_root': '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.rpiimager',
           'installs_item_paths': ['/Applications/Raspberry Pi Imager.app']}}
MunkiInstallsItemsCreator: Created installs item for /Applications/Raspberry Pi Imager.app
{'Output': {'additional_pkginfo': {'installs': [{'CFBundleIdentifier': 'org.raspberrypi.imagingutility',
                                                 'CFBundleName': 'Raspberry Pi '
                                                                 'Imager',
                                                 'CFBundleShortVersionString': '1.8.3',
                                                 'CFBundleVersion': '1.8.3',
                                                 'path': '/Applications/Raspberry '
                                                         'Pi Imager.app',
                                                 'type': 'application',
                                                 'version_comparison_key': 'CFBundleShortVersionString'}]}}}
MunkiPkginfoMerger
{'Input': {'additional_pkginfo': {'installs': [{'CFBundleIdentifier': 'org.raspberrypi.imagingutility',
                                                'CFBundleName': 'Raspberry Pi '
                                                                'Imager',
                                                'CFBundleShortVersionString': '1.8.3',
                                                'CFBundleVersion': '1.8.3',
                                                'path': '/Applications/Raspberry '
                                                        'Pi Imager.app',
                                                'type': 'application',
                                                'version_comparison_key': 'CFBundleShortVersionString'}]},
           'pkginfo': {'catalogs': ['testing'],
                       'category': 'Productivity',
                       'description': 'Use Raspberry Pi Imager for an easy way '
                                      'to install Raspberry Pi OS and other '
                                      'operating systems to an SD card ready '
                                      'to use with your Raspberry Pi.',
                       'developer': 'Raspberry Pi Foundation',
                       'display_name': 'Raspberry Pi Imaging Utility',
                       'name': 'RPiImager',
                       'unattended_install': True,
                       'unattended_uninstall': True,
                       'uninstallable': True}}}
MunkiPkginfoMerger: Merged {'installs': [{'CFBundleIdentifier': 'org.raspberrypi.imagingutility', 'CFBundleName': 'Raspberry Pi Imager', 'CFBundleShortVersionString': '1.8.3', 'CFBundleVersion': '1.8.3', 'path': '/Applications/Raspberry Pi Imager.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}]} into pkginfo
{'Output': {'pkginfo': {'catalogs': ['testing'],
                        'category': 'Productivity',
                        'description': 'Use Raspberry Pi Imager for an easy '
                                       'way to install Raspberry Pi OS and '
                                       'other operating systems to an SD card '
                                       'ready to use with your Raspberry Pi.',
                        'developer': 'Raspberry Pi Foundation',
                        'display_name': 'Raspberry Pi Imaging Utility',
                        'installs': [{'CFBundleIdentifier': 'org.raspberrypi.imagingutility',
                                      'CFBundleName': 'Raspberry Pi Imager',
                                      'CFBundleShortVersionString': '1.8.3',
                                      'CFBundleVersion': '1.8.3',
                                      'path': '/Applications/Raspberry Pi '
                                              'Imager.app',
                                      'type': 'application',
                                      'version_comparison_key': 'CFBundleShortVersionString'}],
                        'name': 'RPiImager',
                        'unattended_install': True,
                        'unattended_uninstall': True,
                        'uninstallable': True}}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'pkg_path': '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.rpiimager/Raspberry '
                       'Pi Imager-1.8.3.pkg',
           'pkginfo': {'catalogs': ['testing'],
                       'category': 'Productivity',
                       'description': 'Use Raspberry Pi Imager for an easy way '
                                      'to install Raspberry Pi OS and other '
                                      'operating systems to an SD card ready '
                                      'to use with your Raspberry Pi.',
                       'developer': 'Raspberry Pi Foundation',
                       'display_name': 'Raspberry Pi Imaging Utility',
                       'installs': [{'CFBundleIdentifier': 'org.raspberrypi.imagingutility',
                                     'CFBundleName': 'Raspberry Pi Imager',
                                     'CFBundleShortVersionString': '1.8.3',
                                     'CFBundleVersion': '1.8.3',
                                     'path': '/Applications/Raspberry Pi '
                                             'Imager.app',
                                     'type': 'application',
                                     'version_comparison_key': 'CFBundleShortVersionString'}],
                       'name': 'RPiImager',
                       'unattended_install': True,
                       'unattended_uninstall': True,
                       'uninstallable': True},
           'repo_subdirectory': 'apps'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/RPiImager-1.8.3.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/Raspberry Pi Imager-1.8.3.pkg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'RPiImager',
                                                       'pkg_repo_path': 'apps/Raspberry '
                                                                        'Pi '
                                                                        'Imager-1.8.3.pkg',
                                                       'pkginfo_path': 'apps/RPiImager-1.8.3.plist',
                                                       'version': '1.8.3'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'paul.cossey',
                                         'creation_date': datetime.datetime(2023, 12, 6, 13, 58, 16),
                                         'munki_version': '6.3.2.4588',
                                         'os_version': '14.1.2'},
                           'autoremove': False,
                           'catalogs': ['testing'],
                           'category': 'Productivity',
                           'description': 'Use Raspberry Pi Imager for an easy '
                                          'way to install Raspberry Pi OS and '
                                          'other operating systems to an SD '
                                          'card ready to use with your '
                                          'Raspberry Pi.',
                           'developer': 'Raspberry Pi Foundation',
                           'display_name': 'Raspberry Pi Imaging Utility',
                           'installed_size': 177612,
                           'installer_item_hash': '88bd5cb4c8f7de4fb6d9814b7275b75affdb2bc45785a4bac7acdd88cbc34702',
                           'installer_item_location': 'apps/Raspberry Pi '
                                                      'Imager-1.8.3.pkg',
                           'installer_item_size': 65756,
                           'installs': [{'CFBundleIdentifier': 'org.raspberrypi.imagingutility',
                                         'CFBundleName': 'Raspberry Pi Imager',
                                         'CFBundleShortVersionString': '1.8.3',
                                         'CFBundleVersion': '1.8.3',
                                         'path': '/Applications/Raspberry Pi '
                                                 'Imager.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'minimum_os_version': '10.5.0',
                           'name': 'RPiImager',
                           'receipts': [{'installed_size': 177612,
                                         'packageid': 'org.raspberrypi.imagingutility',
                                         'version': '1.8.3'}],
                           'unattended_install': True,
                           'unattended_uninstall': True,
                           'uninstall_method': 'removepackages',
                           'uninstallable': True,
                           'version': '1.8.3'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/apps/Raspberry Pi '
                             'Imager-1.8.3.pkg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/apps/RPiImager-1.8.3.plist'}}
PathDeleter
{'Input': {'path_list': ['/Users/paul.cossey/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.rpiimager/Applications']}}
PathDeleter: Deleted /Users/paul.cossey/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.rpiimager/Applications
{'Output': {}}
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.rpiimager/receipts/RPiImager.munki-receipt-20231206-135816.plist

The following new items were imported into Munki:
    Name       Version  Catalogs  Pkginfo Path                Pkg Repo Path                       Icon Repo Path  
    ----       -------  --------  ------------                -------------                       --------------  
    RPiImager  1.8.3    testing   apps/RPiImager-1.8.3.plist  apps/Raspberry Pi Imager-1.8.3.pkg
``