### PR TITLE
Update all available URLs from HTTP to HTTPS

### DIFF
--- a/Oracle/OracleJavaSEDK9.download.recipe
+++ b/Oracle/OracleJavaSEDK9.download.recipe
@@ -23,7 +23,7 @@
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>http://www.oracle.com/technetwork/java/javase/downloads/jdk9-downloads-3848520.html</string>
+                <string>https://www.oracle.com/technetwork/java/javase/downloads/jdk9-downloads-3848520.html</string>
                 <key>re_pattern</key>
                 <string>(?P&lt;url&gt;http://download.oracle.com/otn-pub/java/jdk/.*?/jdk-9.[.0-9]+_osx-x64_bin.dmg)</string>
                 <key>request_headers</key>

--- a/SquirreLSQL/SQuirreLSQL.download.recipe
+++ b/SquirreLSQL/SQuirreLSQL.download.recipe
@@ -21,7 +21,7 @@
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>http://squirrel-sql.sourceforge.net/#installation</string>
+                <string>https://squirrel-sql.sourceforge.net/#installation</string>
                 <key>re_pattern</key>
                 <string>href="(http://sourceforge.net/projects/squirrel-sql/.*-install.jar/download)"&gt;Install jar of SQuirreL .* for Mac.*</string>
                 <key>result_output_var_name</key>


### PR DESCRIPTION
It's important to use HTTPS for downloading software whenever possible in order to avoid the possibility of person-in-the-middle attacks (like the one that affected the Sparkle update framework [in January 2016](https://vulnsec.com/2016/osx-apps-vulnerabilities/)).

For this pull request, I detected and changed to HTTPS URLs automatically using my [HTTPS Spotter](https://www.elliotjordan.com/posts/autopkg-https/) script, and then tested all changed recipes manually to ensure exit codes of recipe run remains the same before/after the change.

This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso).

Thanks for considering!