### PR TITLE
Update rpiimager recipes

### DIFF
--- a/RPiImager/RPiImager.download.recipe
+++ b/RPiImager/RPiImager.download.recipe
@@ -42,7 +42,7 @@
                 <key>input_path</key>
                 <string>%pathname%/Raspberry Pi Imager.app</string>
                 <key>requirement</key>
-                <string>identifier "org.raspberrypi.imagingutility" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = WYH7G79LM6</string>
+                <string>identifier "org.raspberrypi.imagingutility" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "8RDZTRXE62"</string>
             </dict>
         </dict>
     </array>

--- a/RPiImager/RPiImager.munki.recipe
+++ b/RPiImager/RPiImager.munki.recipe
@@ -48,7 +48,6 @@
                 <key>destination_path</key>
                 <string>%RECIPE_CACHE_DIR%/Applications/Raspberry Pi Imager.app</string>
                 <key>source_path</key>
-                <string>%RECIPE_CACHE_DIR%/downloads/Raspberry.Pi.Imager.%version%.dmg/Raspberry Pi Imager.app</string>
                 <string>%pathname%/Raspberry Pi Imager.app</string>
             </dict>
             <key>Processor</key>

--- a/RPiImager/RPiImager.munki.recipe
+++ b/RPiImager/RPiImager.munki.recipe
@@ -49,6 +49,7 @@
                 <string>%RECIPE_CACHE_DIR%/Applications/Raspberry Pi Imager.app</string>
                 <key>source_path</key>
                 <string>%RECIPE_CACHE_DIR%/downloads/Raspberry.Pi.Imager.%version%.dmg/Raspberry Pi Imager.app</string>
+                <string>%pathname%/Raspberry Pi Imager.app</string>
             </dict>
             <key>Processor</key>
             <string>Copier</string>


### PR DESCRIPTION
Hi, @barteklk 

The rpiimager recipes are currently failing with the following error
```
Processor: CodeSignatureVerifier: Error: Code signature verification failed. Note that all verifications can be disabled by setting the variable DISABLE_CODE_SIGNATURE_VERIFICATION to a non-empty value.
```

This PR has 
- Updated Team ID 
-- This looks like an expected change with the current release: https://github.com/raspberrypi/rpi-imager/releases/tag/v1.9.0 "Releases are now signed with the new Raspberry Pi Ltd signing key"
- Updated copier path.

Output from a successful -v run
```
autopkg run -v RPiImager.munki.recipe
Looking for com.github.bnpl.autopkg.pkg.rpiimager...
Did not find com.github.bnpl.autopkg.pkg.rpiimager in recipe map
Rebuilding recipe map with current working directories...
Looking for com.github.bnpl.autopkg.pkg.rpiimager...
Found com.github.bnpl.autopkg.pkg.rpiimager in recipe map
Looking for com.github.bnpl.autopkg.download.rpiimager...
Found com.github.bnpl.autopkg.download.rpiimager in recipe map
**load_recipe time: 0.019591708000007202
Processing RPiImager.munki.recipe...
WARNING: RPiImager.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
GitHubReleasesInfoProvider: Matched regex '.*\.dmg' among asset(s): Raspberry.Pi.Imager-1.9.0.dmg
GitHubReleasesInfoProvider: Selected asset 'Raspberry.Pi.Imager-1.9.0.dmg' from tag 'v1.9.0' at url https://github.com/raspberrypi/rpi-imager/releases/download/v1.9.0/Raspberry.Pi.Imager-1.9.0.dmg
URLDownloader
URLDownloader: Storing new Last-Modified header: Wed, 11 Sep 2024 16:57:20 GMT
URLDownloader: Storing new ETag header: "0x8DCD282CD1552AA"
URLDownloader: Downloaded /Users/paul.cossey/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.rpiimager/downloads/Raspberry.Pi.Imager-1.9.0.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.rpiimager/downloads/Raspberry.Pi.Imager-1.9.0.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.QREonv/Raspberry Pi Imager.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.QREonv/Raspberry Pi Imager.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.QREonv/Raspberry Pi Imager.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
AppPkgCreator
AppPkgCreator: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.rpiimager/downloads/Raspberry.Pi.Imager-1.9.0.dmg
AppPkgCreator: Using path '/private/tmp/dmg.GFWhbz/Raspberry Pi Imager.app' matched from globbed '/private/tmp/dmg.GFWhbz/*.app'.
AppPkgCreator: BundleID: org.raspberrypi.imagingutility
AppPkgCreator: Copied /private/tmp/dmg.GFWhbz/Raspberry Pi Imager.app to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.rpiimager/payload/Applications/Raspberry Pi Imager.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
Copier
Copier: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.rpiimager/downloads/Raspberry.Pi.Imager-1.9.0.dmg
Copier: Copied /private/tmp/dmg.024vIR/Raspberry Pi Imager.app to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.rpiimager/Applications/Raspberry Pi Imager.app
MunkiInstallsItemsCreator
MunkiInstallsItemsCreator: Created installs item for /Applications/Raspberry Pi Imager.app
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'installs': [{'CFBundleIdentifier': 'org.raspberrypi.imagingutility', 'CFBundleName': 'Raspberry Pi Imager', 'CFBundleShortVersionString': '1.9.0', 'CFBundleVersion': '1.9.0', 'path': '/Applications/Raspberry Pi Imager.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}]} into pkginfo
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/RPiImager-1.9.0__1.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/Raspberry Pi Imager-1.9.0__1.pkg
PathDeleter
PathDeleter: Deleted /Users/paul.cossey/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.rpiimager/Applications
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.rpiimager/receipts/RPiImager.munki-receipt-20240920-095159.plist

The following new items were downloaded:
    Download Path                                                                                                             
    -------------                                                                                                             
    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.rpiimager/downloads/Raspberry.Pi.Imager-1.9.0.dmg  

The following packages were built:
    Identifier                      Version  Pkg Path                                                                                                        
    ----------                      -------  --------                                                                                                        
    org.raspberrypi.imagingutility  1.9.0    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.rpiimager/Raspberry Pi Imager-1.9.0.pkg  

The following new items were imported into Munki:
    Name       Version  Catalogs  Pkginfo Path                   Pkg Repo Path                          Icon Repo Path  
    ----       -------  --------  ------------                   -------------                          --------------  
    RPiImager  1.9.0    testing   apps/RPiImager-1.9.0__1.plist  apps/Raspberry Pi Imager-1.9.0__1.pkg
```