### PR TITLE
Clarify that Postman recipes can be used to download either Intel or Apple Silicon versions of Postman

### DIFF
--- a/Postman/Postman.download.recipe
+++ b/Postman/Postman.download.recipe
@@ -3,7 +3,12 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the current release version of Postman.</string>
+    <string>Downloads the current release version of Postman.
+    
+The default DOWNLOAD_URL downloads the Intel version of Postman. To download 
+the Apple Silicon version of Postman, use this DOWNLOAD_URL:
+https://dl.pstmn.io/download/latest/osx_arm64
+</string>
     <key>Identifier</key>
     <string>com.github.bnpl.autopkg.download.postman</string>
     <key>Input</key>
@@ -18,7 +23,7 @@
     <key>Process</key>
     <array>
         <dict>
-  			<key>Arguments</key>
+            <key>Arguments</key>
             <dict>
                 <key>filename</key>
                 <string>%NAME%.zip</string>

--- a/Postman/Postman.download.recipe
+++ b/Postman/Postman.download.recipe
@@ -12,8 +12,6 @@
         <string>https://dl.pstmn.io/download/latest/osx</string>
         <key>NAME</key>
         <string>Postman</string>
-        <key>DOWNLOAD_URL</key>
-        <string>https://dl.pstmn.io/download/latest/osx</string>        
     </dict>
     <key>MinimumVersion</key>
     <string>1.0.0</string>

--- a/Postman/Postman.munki.recipe
+++ b/Postman/Postman.munki.recipe
@@ -3,7 +3,10 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the current release version of Postman, builds a package and imports it to Munki.</string>
+    <string>Downloads the current release version of Postman, builds a package and imports it to Munki.
+    
+If overriding the DOWNLOAD_URL for Apple Silicon architecture, be sure to supply a
+supported_architectures array containing the string "arm64".</string>
     <key>Identifier</key>
     <string>com.github.bnpl.autopkg.munki.postman</string>
     <key>Input</key>
@@ -32,6 +35,10 @@
             <string>Postman</string>
             <key>name</key>
             <string>%NAME%</string>
+            <key>supported_architectures</key>
+            <array>
+                <string>x86_64</string>
+            </array>
             <key>unattended_install</key>
             <true/>
             <key>unattended_uninstall</key>


### PR DESCRIPTION
This pull request attempts to clarify the fact that these Postman recipes can already be used to download either Intel or Apple Silicon versions of Postman, via customization of the `DOWNLOAD_URL` input variable. Making this clearer will allow us to deprecate and remove arm64-specific versions of the Postman recipe in other repos.