### PR TITLE
Fix SquirrelSQL recipes

### DIFF
--- a/SquirreLSQL/SQuirreLSQL.download.recipe
+++ b/SquirreLSQL/SQuirreLSQL.download.recipe
@@ -17,56 +17,13 @@
     <array>
         <dict>
             <key>Processor</key>
-            <string>URLTextSearcher</string>
+            <string>com.github.jessepeterson.munki.GrandPerspective/SourceForgeURLProvider</string>
             <key>Arguments</key>
             <dict>
-                <key>url</key>
-                <string>https://squirrel-sql.sourceforge.net/#installation</string>
-                <key>re_pattern</key>
-                <string>href="(http://sourceforge.net/projects/squirrel-sql/.*-install.jar/download)"&gt;Install jar of SQuirreL .* for Mac.*</string>
-                <key>result_output_var_name</key>
-                <string>prematch</string>
-                <key>request_headers</key>
-                <dict>
-                    <key>user-agent</key>
-                    <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:46.0) Gecko/20100101 Firefox/46.0</string>
-                </dict>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>URLTextSearcher</string>
-            <key>Arguments</key>
-            <dict>
-                <key>url</key>
-                <string>%prematch%</string>
-                <key>re_pattern</key>
-                <string>http-equiv="refresh" content=".*; url=(.*)"</string>
-                <key>result_output_var_name</key>
-                <string>match</string>
-                <key>request_headers</key>
-                <dict>
-                    <key>user-agent</key>
-                    <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:46.0) Gecko/20100101 Firefox/46.0</string>
-                </dict>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>URLTextSearcher</string>
-            <key>Arguments</key>
-            <dict>
-                <key>url</key>
-                <string>%prematch%</string>
-                <key>re_pattern</key>
-                <string>http-equiv="refresh" content=".*; url=.*/(.*\.jar).*"</string>
-                <key>result_output_var_name</key>
-                <string>namematch</string>
-                <key>request_headers</key>
-                <dict>
-                    <key>user-agent</key>
-                    <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:46.0) Gecko/20100101 Firefox/46.0</string>
-                </dict>
+                <key>SOURCEFORGE_PROJECT_ID</key>
+                <string>28383</string>
+                <key>SOURCEFORGE_FILE_PATTERN</key>
+                <string>\.jar</string>
             </dict>
         </dict>
         <dict>
@@ -74,12 +31,8 @@
             <string>URLDownloader</string>
             <key>Arguments</key>
             <dict>
-                <key>url</key>
-                <string>%match%</string>
                 <key>filename</key>
-                <string>%namematch%</string>
-                <key>CHECK_FILESIZE_ONLY</key>
-                <true/>
+                <string>%NAME%.jar</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
This PR updates the SquirrelSQL download method to use @jessepeterson's SourceForgeURLProvider.

Verbose download recipe run:

```
% autopkg run -vvq 'SquirreLSQL/SQuirreLSQL.download.recipe'
Processing SquirreLSQL/SQuirreLSQL.download.recipe...
WARNING: SquirreLSQL/SQuirreLSQL.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
com.github.jessepeterson.munki.GrandPerspective/SourceForgeURLProvider
{'Input': {'SOURCEFORGE_FILE_PATTERN': '\\.jar',
           'SOURCEFORGE_PROJECT_ID': '28383'}}
SourceForgeURLProvider: File URL https://sourceforge.net/projects/squirrel-sql/files/3-snapshots/snapshot-20241219_2026/squirrel-sql-snapshot-20241219_2026-MACOSX-install.jar/download
{'Output': {'url': 'https://sourceforge.net/projects/squirrel-sql/files/3-snapshots/snapshot-20241219_2026/squirrel-sql-snapshot-20241219_2026-MACOSX-install.jar/download'}}
URLDownloader
{'Input': {'filename': 'SQuirreLSQL.jar',
           'url': 'https://sourceforge.net/projects/squirrel-sql/files/3-snapshots/snapshot-20241219_2026/squirrel-sql-snapshot-20241219_2026-MACOSX-install.jar/download'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Thu, 19 Dec 2024 19:27:13 GMT
URLDownloader: Storing new ETag header: "67647391-3dd5b2f"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.bnpl.autopkg.download.squirrelsql/downloads/SQuirreLSQL.jar
{'Output': {'download_changed': True,
            'etag': '"67647391-3dd5b2f"',
            'last_modified': 'Thu, 19 Dec 2024 19:27:13 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.bnpl.autopkg.download.squirrelsql/downloads/SQuirreLSQL.jar',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.bnpl.autopkg.download.squirrelsql/downloads/SQuirreLSQL.jar'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.bnpl.autopkg.download.squirrelsql/receipts/SQuirreLSQL.download-receipt-20241225-115905.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.bnpl.autopkg.download.squirrelsql/downloads/SQuirreLSQL.jar
```
