### PR TITLE
Deprecate Oracle Java SE DK 9 recipes

### DIFF
--- a/Oracle/OracleJavaSEDK9.download.recipe
+++ b/Oracle/OracleJavaSEDK9.download.recipe
@@ -19,6 +19,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Oracle Java SE DK 9 is no longer under development (archive: https://www.oracle.com/java/technologies/javase/javase9-archive-downloads.html). This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>URLTextSearcher</string>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
This PR deprecates the Oracle Java SE DK 9 recipes.
