### PR TITLE
Remove unneeded user-agent for FreeFileSync download

### DIFF
--- a/FreeFileSync/FreeFileSync.download.recipe
+++ b/FreeFileSync/FreeFileSync.download.recipe
@@ -26,11 +26,6 @@
                 <string>href=".*download/(.*FreeFileSync_.*_macOS)\.zip"</string>
                 <key>result_output_var_name</key>
                 <string>match</string>
-                <key>request_headers</key>
-                <dict>
-                    <key>user-agent</key>
-                    <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:46.0) Gecko/20100101 Firefox/46.0</string>
-                </dict>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
This PR removes the unneeded `user-agent` header for downloading FreeFileSync.
