### PR TITLE
Remove unnecessary user-agent headers from pgAdmin4.download recipe

### DIFF
--- a/pgAdmin4/pgAdmin4.download.recipe
+++ b/pgAdmin4/pgAdmin4.download.recipe
@@ -10,8 +10,6 @@
     <dict>
         <key>NAME</key>
         <string>pgAdmin4</string>
-        <key>USER_AGENT</key>
-        <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:46.0) Gecko/20100101 Firefox/46.0</string>
         <key>ARCH</key>
         <string>x86_64</string>
     </dict>
@@ -28,11 +26,6 @@
                 <string>https://www.pgadmin.org/download/pgadmin-4-macos/</string>
                 <key>re_pattern</key>
                 <string>href="(https://.*?/macos/)"&gt;pg</string>
-                <key>request_headers</key>
-                <dict>
-                    <key>user-agent</key>
-                    <string>%USER_AGENT%</string>
-                </dict>
             </dict>
         </dict>
         <dict>
@@ -44,11 +37,6 @@
                 <string>%match%</string>
                 <key>re_pattern</key>
                 <string>href="(https://.*?%ARCH%\.dmg)"&gt;&lt;</string>
-                <key>request_headers</key>
-                <dict>
-                    <key>user-agent</key>
-                    <string>%USER_AGENT%</string>
-                </dict>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
This PR removes the user-agent header from the pgAdmin4.download recipe, as it doesn't seem to be needed for downloading the software and its removal decreases the maintenance needed to keep the recipe up to date in the future.

Verbose recipe run output:

```
% autopkg run -vvq 'pgAdmin4/pgAdmin4.download.recipe'
Processing pgAdmin4/pgAdmin4.download.recipe...
WARNING: pgAdmin4/pgAdmin4.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'href="(https://.*?/macos/)">pg',
           'url': 'https://www.pgadmin.org/download/pgadmin-4-macos/'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (match): https://www.postgresql.org/ftp/pgadmin/pgadmin4/v8.14/macos/
{'Output': {'match': 'https://www.postgresql.org/ftp/pgadmin/pgadmin4/v8.14/macos/'}}
URLTextSearcher
{'Input': {'re_pattern': 'href="(https://.*?x86_64\\.dmg)"><',
           'result_output_var_name': 'match',
           'url': 'https://www.postgresql.org/ftp/pgadmin/pgadmin4/v8.14/macos/'}}
URLTextSearcher: Found matching text (match): https://ftp.postgresql.org/pub/pgadmin/pgadmin4/v8.14/macos/pgadmin4-8.14-x86_64.dmg
{'Output': {'match': 'https://ftp.postgresql.org/pub/pgadmin/pgadmin4/v8.14/macos/pgadmin4-8.14-x86_64.dmg'}}
URLDownloader
{'Input': {'CHECK_FILESIZE_ONLY': True,
           'url': 'https://ftp.postgresql.org/pub/pgadmin/pgadmin4/v8.14/macos/pgadmin4-8.14-x86_64.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: Storing new Last-Modified header: Thu, 12 Dec 2024 06:29:37 GMT
URLDownloader: Storing new ETag header: "675a82d1-cc12f1a"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.bnpl.autopkg.download.pgadmin4/downloads/pgadmin4-8.14-x86_64.dmg
{'Output': {'download_changed': True,
            'etag': '"675a82d1-cc12f1a"',
            'last_modified': 'Thu, 12 Dec 2024 06:29:37 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.bnpl.autopkg.download.pgadmin4/downloads/pgadmin4-8.14-x86_64.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.bnpl.autopkg.download.pgadmin4/downloads/pgadmin4-8.14-x86_64.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.bnpl.autopkg.download.pgadmin4/downloads/pgadmin4-8.14-x86_64.dmg/pgAdmin '
                         '4.app',
           'requirement': 'identifier "org.pgadmin.pgadmin4" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'TCHGL2R7C5'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.bnpl.autopkg.download.pgadmin4/downloads/pgadmin4-8.14-x86_64.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.4vZ8Vw/pgAdmin 4.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.4vZ8Vw/pgAdmin 4.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.4vZ8Vw/pgAdmin 4.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.bnpl.autopkg.download.pgadmin4/receipts/pgAdmin4.download-receipt-20250101-190802.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.bnpl.autopkg.download.pgadmin4/downloads/pgadmin4-8.14-x86_64.dmg
```
