### PR TITLE
Add JetBrains RustRover Recipes

### DIFF
--- a/JetBrains/RustRover.download.recipe
+++ b/JetBrains/RustRover.download.recipe
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the current release version of RustRover.</string>
+    <key>Comment</key>
+    <string>For the ARCH_TYPE variable use "mac" for Intel, use "macM1" for Apple Silicon</string>
+    <key>Identifier</key>
+    <string>com.github.bnpl.autopkg.download.rustrover</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>RustRover</string>
+        <key>ARCH_TYPE</key>
+        <string>mac</string>
+        <key>PROD_CODE</key>
+        <string>RR</string>
+        <key>CSV_REQ</key>
+        <string>identifier "com.jetbrains.rustrover" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "2ZEFAR8TH3"</string>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>0.2.0</string>
+    <key>ParentRecipe</key>
+    <string>com.github.bnpl.autopkg.download.jetbrains</string>
+</dict>
+</plist>

--- a/JetBrains/RustRover.munki.recipe
+++ b/JetBrains/RustRover.munki.recipe
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the current release version of RustRover and imports into Munki.</string>
+    <key>Comment</key>
+    <string>For the SUPPORTED_ARCH variable use "x86_64" for Intel, use "arm64" for Apple Silicon</string>
+    <key>Identifier</key>
+    <string>com.github.bnpl.autopkg.munki.rustrover</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>RustRover</string>
+        <key>MUNKI_REPO_SUBDIR</key>
+        <string>apps/jetbrains</string>
+        <key>SUPPORTED_ARCH</key>
+        <string>x86_64</string>
+        <key>pkginfo</key>
+        <dict>
+            <key>catalogs</key>
+            <array>
+                <string>testing</string>
+            </array>
+            <key>category</key>
+            <string>Developer Tools</string>
+            <key>description</key>
+            <string>A powerhouse IDE for Rust developers
+
+https://www.jetbrains.com/rust</string>
+            <key>developer</key>
+            <string>JetBrains</string>
+            <key>display_name</key>
+            <string>RustRover</string>
+            <key>name</key>
+            <string>%NAME%</string>
+            <key>supported_architectures</key>
+            <array>
+                <string>%SUPPORTED_ARCH%</string>
+            </array>
+            <key>unattended_install</key>
+            <true/>
+            <key>unattended_uninstall</key>
+            <true/>
+            <key>uninstallable</key>
+            <true/>
+        </dict>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>0.4.3</string>
+    <key>ParentRecipe</key>
+    <string>com.github.bnpl.autopkg.download.rustrover</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiImporter</string>
+            <key>Arguments</key>
+            <dict>
+                <key>munkiimport_appname</key>
+                <string>RustRover.app</string>
+                <key>pkg_path</key>
+                <string>%pathname%</string>
+                <key>repo_subdirectory</key>
+                <string>%MUNKI_REPO_SUBDIR%</string>
+            </dict>
+        </dict>
+    </array>
+</dict>
+</plist>


### PR DESCRIPTION
Hi, @barteklk 

This PR adds download and munki recipes for RustRover to the JetBrains recipe collection. We're happy to host if you don't want them, but it makes more sense to add them here.

Output from successful x86_64 and arm64 runs
```
autopkg run -v RustRover.munki.recipe
Looking for com.github.bnpl.autopkg.download.rustrover...
Did not find com.github.bnpl.autopkg.download.rustrover in recipe map
Rebuilding recipe map with current working directories...
Looking for com.github.bnpl.autopkg.download.rustrover...
Found com.github.bnpl.autopkg.download.rustrover in recipe map
Looking for com.github.bnpl.autopkg.download.jetbrains...
Found com.github.bnpl.autopkg.download.jetbrains in recipe map
**load_recipe time: 0.010228290979284793
Processing RustRover.munki.recipe...
WARNING: RustRover.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
URLTextSearcher: Found matching text (match): https://download.jetbrains.com/rustrover/RustRover-2024.3.2.dmg
URLDownloader
URLDownloader: Storing new Last-Modified header: Thu, 19 Dec 2024 11:52:18 GMT
URLDownloader: Storing new ETag header: "8c6d113fd4dd73e664b05ce1f349300d-134"
URLDownloader: Downloaded /Users/paul.cossey/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.rustrover/downloads/RustRover-2024.3.2.dmg
FileFinder
FileFinder: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.rustrover/downloads/RustRover-2024.3.2.dmg
FileFinder: Found file match: '/private/tmp/dmg.YqvlR9/RustRover.app' from globbed '/private/tmp/dmg.YqvlR9/*.app'
FileFinder: DMG-relative file match: 'RustRover.app'
FileFinder: Basename match: 'RustRover.app'
PlistReader
PlistReader: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.rustrover/downloads/RustRover-2024.3.2.dmg
PlistReader: Reading: /private/tmp/dmg.iy7bch/RustRover.app/Contents/Info.plist
PlistReader: Assigning value of '2024.3.2' to output variable 'version'
PlistReader: Assigning value of '10.13' to output variable 'min_os_vers'
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.rustrover/downloads/RustRover-2024.3.2.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification enabled...
CodeSignatureVerifier: /private/tmp/dmg.s9qF4O/RustRover.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.s9qF4O/RustRover.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.s9qF4O/RustRover.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
EndOfCheckPhase
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/jetbrains/RustRover-2024.3.2-x86_64.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/jetbrains/RustRover-2024.3.2.dmg
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.rustrover/receipts/RustRover.munki-receipt-20250108-165515.plist

The following new items were downloaded:
    Download Path                                                                                                      
    -------------                                                                                                      
    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.rustrover/downloads/RustRover-2024.3.2.dmg  

The following new items were imported into Munki:
    Name       Version   Catalogs  Pkginfo Path                                    Pkg Repo Path                          Icon Repo Path  
    ----       -------   --------  ------------                                    -------------                          --------------  
    RustRover  2024.3.2  testing   apps/jetbrains/RustRover-2024.3.2-x86_64.plist  apps/jetbrains/RustRover-2024.3.2.dmg
```
```
autopkg run -v RustRover.munki.recipe
Looking for com.github.bnpl.autopkg.download.rustrover...
Did not find com.github.bnpl.autopkg.download.rustrover in recipe map
Rebuilding recipe map with current working directories...
Looking for com.github.bnpl.autopkg.download.rustrover...
Found com.github.bnpl.autopkg.download.rustrover in recipe map
Looking for com.github.bnpl.autopkg.download.jetbrains...
Found com.github.bnpl.autopkg.download.jetbrains in recipe map
**load_recipe time: 0.012349541997537017
Processing RustRover.munki.recipe...
WARNING: RustRover.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
URLTextSearcher: Found matching text (match): https://download.jetbrains.com/rustrover/RustRover-2024.3.2-aarch64.dmg
URLDownloader
URLDownloader: Storing new Last-Modified header: Thu, 19 Dec 2024 11:52:18 GMT
URLDownloader: Storing new ETag header: "e22c25c8cc14c678568eda8c61c851bd-133"
URLDownloader: Downloaded /Users/paul.cossey/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.rustrover/downloads/RustRover-2024.3.2-aarch64.dmg
FileFinder
FileFinder: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.rustrover/downloads/RustRover-2024.3.2-aarch64.dmg
FileFinder: Found file match: '/private/tmp/dmg.Cv1IqT/RustRover.app' from globbed '/private/tmp/dmg.Cv1IqT/*.app'
FileFinder: DMG-relative file match: 'RustRover.app'
FileFinder: Basename match: 'RustRover.app'
PlistReader
PlistReader: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.rustrover/downloads/RustRover-2024.3.2-aarch64.dmg
PlistReader: Reading: /private/tmp/dmg.cGA0a1/RustRover.app/Contents/Info.plist
PlistReader: Assigning value of '2024.3.2' to output variable 'version'
PlistReader: Assigning value of '10.13' to output variable 'min_os_vers'
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.rustrover/downloads/RustRover-2024.3.2-aarch64.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification enabled...
CodeSignatureVerifier: /private/tmp/dmg.xXCGV2/RustRover.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.xXCGV2/RustRover.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.xXCGV2/RustRover.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
EndOfCheckPhase
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/jetbrains/RustRover-2024.3.2-arm64.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/jetbrains/RustRover-2024.3.2-aarch64-2024.3.2.dmg
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.rustrover/receipts/RustRover.munki-receipt-20250108-171016.plist

The following new items were downloaded:
    Download Path                                                                                                              
    -------------                                                                                                              
    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.rustrover/downloads/RustRover-2024.3.2-aarch64.dmg  

The following new items were imported into Munki:
    Name       Version   Catalogs  Pkginfo Path                                   Pkg Repo Path                                           Icon Repo Path  
    ----       -------   --------  ------------                                   -------------                                           --------------  
    RustRover  2024.3.2  testing   apps/jetbrains/RustRover-2024.3.2-arm64.plist  apps/jetbrains/RustRover-2024.3.2-aarch64-2024.3.2.dmg
```