### PR TITLE
Add JetBrains Gateway recipes

### DIFF
--- a/JetBrains/Gateway.download.recipe
+++ b/JetBrains/Gateway.download.recipe
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the current release version of JetBrains Gateway.</string>
+    <key>Comment</key>
+    <string>For the ARCH_TYPE variable use "mac" for Intel, use "macM1" for Apple Silicon</string>
+    <key>Identifier</key>
+    <string>com.github.bnpl.autopkg.download.jetbrainsgateway</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>JetBrains Gateway</string>
+        <key>ARCH_TYPE</key>
+        <string>macM1</string>
+        <key>PROD_CODE</key>
+        <string>GW</string>
+        <key>CSV_REQ</key>
+        <string>identifier "com.jetbrains.gateway" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "2ZEFAR8TH3"</string>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>0.2.0</string>
+    <key>ParentRecipe</key>
+    <string>com.github.bnpl.autopkg.download.jetbrains</string>
+</dict>
+</plist>

--- a/JetBrains/Gateway.munki.recipe
+++ b/JetBrains/Gateway.munki.recipe
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the current release version of JetBrains Gateway and imports into Munki.</string>
+    <key>Comment</key>
+    <string>For the SUPPORTED_ARCH variable use "x86_64" for Intel, use "arm64" for Apple Silicon</string>
+    <key>Identifier</key>
+    <string>com.github.bnpl.autopkg.munki.jetbrainsgateway</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>JetBrains Gateway</string>
+        <key>MUNKI_REPO_SUBDIR</key>
+        <string>apps/jetbrains</string>
+        <key>SUPPORTED_ARCH</key>
+        <string>arm64</string>
+        <key>pkginfo</key>
+        <dict>
+            <key>catalogs</key>
+            <array>
+                <string>testing</string>
+            </array>
+            <key>category</key>
+            <string>Developer Tools</string>
+            <key>description</key>
+            <string>JetBrains Gateway is a compact desktop app that allows you to work remotely with a JetBrains IDE without even downloading one.</string>
+            <key>developer</key>
+            <string>JetBrains</string>
+            <key>display_name</key>
+            <string>JetBrains Gateway</string>
+            <key>name</key>
+            <string>%NAME%</string>
+            <key>supported_architectures</key>
+            <array>
+                <string>%SUPPORTED_ARCH%</string>
+            </array>
+            <key>unattended_install</key>
+            <true/>
+            <key>unattended_uninstall</key>
+            <true/>
+            <key>uninstallable</key>
+            <true/>
+        </dict>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>0.4.3</string>
+    <key>ParentRecipe</key>
+    <string>com.github.bnpl.autopkg.download.jetbrainsgateway</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiImporter</string>
+            <key>Arguments</key>
+            <dict>
+                <key>pkg_path</key>
+                <string>%pathname%</string>
+                <key>repo_subdirectory</key>
+                <string>%MUNKI_REPO_SUBDIR%</string>
+            </dict>
+        </dict>
+    </array>
+</dict>
+</plist>


### PR DESCRIPTION
This adds download and Munki recipes for JetBrains Gateway.

`-vv` output:

[JetBrainsGateway.download.Arm.txt](https://github.com/user-attachments/files/21110261/JetBrainsGateway.download.Arm.txt)
[JetBrainsGateway.download.Intel.txt](https://github.com/user-attachments/files/21110262/JetBrainsGateway.download.Intel.txt)
[JetBrainsGateway.munki.Intel.txt](https://github.com/user-attachments/files/21110263/JetBrainsGateway.munki.Intel.txt)
[JetBrainsGateway.munki.Arm.txt](https://github.com/user-attachments/files/21110264/JetBrainsGateway.munki.Arm.txt)
