### PR TITLE
Update JetBrains.download.recipe

### DIFF
--- a/JetBrains/JetBrains.download.recipe
+++ b/JetBrains/JetBrains.download.recipe
@@ -44,6 +44,10 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>FileFinder</string>
             <key>Arguments</key>
             <dict>
@@ -79,10 +83,6 @@
                 <key>strict_verification</key>
                 <true/>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
     </array>
 </dict>


### PR DESCRIPTION
Moves the EndOfCheckPhase processor  after the URLDownloader processor. This resolves an issue with using cached metadata. 