### PR TITLE
Update TeXLiveUtility recipes to work with zip download

### DIFF
--- a/TeXLiveUtility/TeXLiveUtility.download.recipe
+++ b/TeXLiveUtility/TeXLiveUtility.download.recipe
@@ -18,13 +18,18 @@
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>github_repo</key>
-                <string>amaxwell/tlutility</string>
+                <key>appcast_url</key>
+                <string>https://raw.githubusercontent.com/amaxwell/tlutility/master/appcast/tlu_appcast.xml</string>
             </dict>
             <key>Processor</key>
-            <string>GitHubReleasesInfoProvider</string>
+            <string>SparkleUpdateInfoProvider</string>
         </dict>
         <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>filename</key>
+                <string>%NAME%-%version%.zip</string>
+            </dict>
             <key>Processor</key>
             <string>URLDownloader</string>
         </dict>
@@ -33,15 +38,28 @@
             <string>EndOfCheckPhase</string>
         </dict>
         <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>archive_path</key>
+                <string>%pathname%</string>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
             <key>Processor</key>
-            <string>CodeSignatureVerifier</string>
+            <string>Unarchiver</string>
+        </dict>
+        <dict>
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%pathname%/TeX Live Utility.app</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/TeX Live Utility.app</string>
                 <key>requirement</key>
-                <string>identifier "com.googlecode.mactlmgr.tlu" and certificate leaf = H"9762c300630034b23fe0eeb054acc8bc889f1346"</string>
+                <string>identifier "com.googlecode.mactlmgr.tlu" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "966Z24PX4J"</string>
             </dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
         </dict>
     </array>
 </dict>

--- a/TeXLiveUtility/TeXLiveUtility.munki.recipe
+++ b/TeXLiveUtility/TeXLiveUtility.munki.recipe
@@ -45,8 +45,19 @@
         <dict>
             <key>Arguments</key>
             <dict>
+                <key>dmg_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
+                <key>dmg_root</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
+            </dict>
+            <key>Processor</key>
+            <string>DmgCreator</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
                 <key>pkg_path</key>
-                <string>%RECIPE_CACHE_DIR%/TeX Live Utility-%version%.pkg</string>
+                <string>%dmg_path%</string>
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
             </dict>

--- a/TeXLiveUtility/TeXLiveUtility.pkg.recipe
+++ b/TeXLiveUtility/TeXLiveUtility.pkg.recipe
@@ -18,6 +18,11 @@
     <key>Process</key>
     <array>
         <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>app_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/TeX Live Utility.app</string>
+            </dict>
             <key>Processor</key>
             <string>AppPkgCreator</string>
         </dict>


### PR DESCRIPTION
The latest release (from February 2023) uses a zip file instead of a dmg. This PR adjusts the recipes accordingly.

Verbose recipe run of download and pkg recipes:

```
% autopkg run -vvq bnpl-recipes/TeXLiveUtility/TeXLiveUtility.{download,pkg}.recipe
Processing bnpl-recipes/TeXLiveUtility/TeXLiveUtility.download.recipe...
WARNING: bnpl-recipes/TeXLiveUtility/TeXLiveUtility.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://raw.githubusercontent.com/amaxwell/tlutility/master/appcast/tlu_appcast.xml'}}
SparkleUpdateInfoProvider: No value supplied for alternate_xmlns_url, setting default value of: http://www.andymatuschak.org/xml-namespaces/sparkle
SparkleUpdateInfoProvider: No value supplied for urlencode_path_component, setting default value of: True
SparkleUpdateInfoProvider: Items in feed: 66
SparkleUpdateInfoProvider: Items in default channel: 66
SparkleUpdateInfoProvider: Version retrieved from appcast: 1.54
SparkleUpdateInfoProvider: Found URL https://github.com/amaxwell/tlutility/releases/download/1.54/TeX.Live.Utility.app-1.54.zip
{'Output': {'url': 'https://github.com/amaxwell/tlutility/releases/download/1.54/TeX.Live.Utility.app-1.54.zip',
            'version': '1.54'}}
URLDownloader
{'Input': {'filename': 'TeXLiveUtility-1.54.zip',
           'url': 'https://github.com/amaxwell/tlutility/releases/download/1.54/TeX.Live.Utility.app-1.54.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.bnpl.autopkg.download.texliveutility/downloads/TeXLiveUtility-1.54.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.bnpl.autopkg.download.texliveutility/downloads/TeXLiveUtility-1.54.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.bnpl.autopkg.download.texliveutility/downloads/TeXLiveUtility-1.54.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.bnpl.autopkg.download.texliveutility/TeXLiveUtility',
           'purge_destination': True}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'zip' from filename TeXLiveUtility-1.54.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.bnpl.autopkg.download.texliveutility/downloads/TeXLiveUtility-1.54.zip to ~/Library/AutoPkg/Cache/com.github.bnpl.autopkg.download.texliveutility/TeXLiveUtility
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.bnpl.autopkg.download.texliveutility/TeXLiveUtility/TeX '
                         'Live Utility.app',
           'requirement': 'identifier "com.googlecode.mactlmgr.tlu" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"966Z24PX4J"'}}
CodeSignatureVerifier: No value supplied for deep_verification, setting default value of: True
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.bnpl.autopkg.download.texliveutility/TeXLiveUtility/TeX Live Utility.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.bnpl.autopkg.download.texliveutility/TeXLiveUtility/TeX Live Utility.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.bnpl.autopkg.download.texliveutility/TeXLiveUtility/TeX Live Utility.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.bnpl.autopkg.download.texliveutility/receipts/TeXLiveUtility.download-receipt-20251025-211705.plist
Processing bnpl-recipes/TeXLiveUtility/TeXLiveUtility.pkg.recipe...
WARNING: bnpl-recipes/TeXLiveUtility/TeXLiveUtility.pkg.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://raw.githubusercontent.com/amaxwell/tlutility/master/appcast/tlu_appcast.xml'}}
SparkleUpdateInfoProvider: No value supplied for alternate_xmlns_url, setting default value of: http://www.andymatuschak.org/xml-namespaces/sparkle
SparkleUpdateInfoProvider: No value supplied for urlencode_path_component, setting default value of: True
SparkleUpdateInfoProvider: Items in feed: 66
SparkleUpdateInfoProvider: Items in default channel: 66
SparkleUpdateInfoProvider: Version retrieved from appcast: 1.54
SparkleUpdateInfoProvider: Found URL https://github.com/amaxwell/tlutility/releases/download/1.54/TeX.Live.Utility.app-1.54.zip
{'Output': {'url': 'https://github.com/amaxwell/tlutility/releases/download/1.54/TeX.Live.Utility.app-1.54.zip',
            'version': '1.54'}}
URLDownloader
{'Input': {'filename': 'TeXLiveUtility-1.54.zip',
           'url': 'https://github.com/amaxwell/tlutility/releases/download/1.54/TeX.Live.Utility.app-1.54.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Sat, 18 Feb 2023 22:52:43 GMT
URLDownloader: Storing new ETag header: "0x8DB1202D8BA44D1"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.bnpl.autopkg.pkg.texliveutility/downloads/TeXLiveUtility-1.54.zip
{'Output': {'download_changed': True,
            'etag': '"0x8DB1202D8BA44D1"',
            'last_modified': 'Sat, 18 Feb 2023 22:52:43 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.bnpl.autopkg.pkg.texliveutility/downloads/TeXLiveUtility-1.54.zip',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.bnpl.autopkg.pkg.texliveutility/downloads/TeXLiveUtility-1.54.zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.bnpl.autopkg.pkg.texliveutility/downloads/TeXLiveUtility-1.54.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.bnpl.autopkg.pkg.texliveutility/TeXLiveUtility',
           'purge_destination': True}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'zip' from filename TeXLiveUtility-1.54.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.bnpl.autopkg.pkg.texliveutility/downloads/TeXLiveUtility-1.54.zip to ~/Library/AutoPkg/Cache/com.github.bnpl.autopkg.pkg.texliveutility/TeXLiveUtility
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.bnpl.autopkg.pkg.texliveutility/TeXLiveUtility/TeX '
                         'Live Utility.app',
           'requirement': 'identifier "com.googlecode.mactlmgr.tlu" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"966Z24PX4J"'}}
CodeSignatureVerifier: No value supplied for deep_verification, setting default value of: True
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.bnpl.autopkg.pkg.texliveutility/TeXLiveUtility/TeX Live Utility.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.bnpl.autopkg.pkg.texliveutility/TeXLiveUtility/TeX Live Utility.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.bnpl.autopkg.pkg.texliveutility/TeXLiveUtility/TeX Live Utility.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {'app_path': '~/Library/AutoPkg/Cache/com.github.bnpl.autopkg.pkg.texliveutility/TeXLiveUtility/TeX '
                       'Live Utility.app',
           'version': '1.54'}}
AppPkgCreator: No value supplied for version_key, setting default value of: CFBundleShortVersionString
AppPkgCreator: No value supplied for force_pkg_build, setting default value of: False
AppPkgCreator: BundleID: com.googlecode.mactlmgr.tlu
AppPkgCreator: Copied ~/Library/AutoPkg/Cache/com.github.bnpl.autopkg.pkg.texliveutility/TeXLiveUtility/TeX Live Utility.app to ~/Library/AutoPkg/Cache/com.github.bnpl.autopkg.pkg.texliveutility/payload/Applications/TeX Live Utility.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.googlecode.mactlmgr.tlu',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.bnpl.autopkg.pkg.texliveutility/TeX '
                                                                    'Live '
                                                                    'Utility-1.54.pkg',
                                                        'version': '1.54'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '1.54'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.bnpl.autopkg.pkg.texliveutility/receipts/TeXLiveUtility.pkg-receipt-20251025-211717.plist

The following new items were downloaded:
    Download Path                                                                                                     
    -------------                                                                                                     
    ~/Library/AutoPkg/Cache/com.github.bnpl.autopkg.pkg.texliveutility/downloads/TeXLiveUtility-1.54.zip  

The following packages were built:
    Identifier                   Version  Pkg Path                                                                                                  
    ----------                   -------  --------                                                                                                  
    com.googlecode.mactlmgr.tlu  1.54     ~/Library/AutoPkg/Cache/com.github.bnpl.autopkg.pkg.texliveutility/TeX Live Utility-1.54.pkg 
```