### PR TITLE
Simplify RPiImager munki recipe

### DIFF
--- a/RPiImager/RPiImager.munki.recipe
+++ b/RPiImager/RPiImager.munki.recipe
@@ -39,58 +39,19 @@
     <key>MinimumVersion</key>
     <string>0.4.3</string>
     <key>ParentRecipe</key>
-    <string>com.github.bnpl.autopkg.pkg.rpiimager</string>
+    <string>com.github.bnpl.autopkg.download.rpiimager</string>
     <key>Process</key>
     <array>
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>destination_path</key>
-                <string>%RECIPE_CACHE_DIR%/Applications/Raspberry Pi Imager.app</string>
-                <key>source_path</key>
-                <string>%pathname%/Raspberry Pi Imager.app</string>
-            </dict>
-            <key>Processor</key>
-            <string>Copier</string>
-        </dict>
-        <dict>
-            <key>Arguments</key>
-            <dict>
-                <key>faux_root</key>
-                <string>%RECIPE_CACHE_DIR%</string>
-                <key>installs_item_paths</key>
-                <array>
-                    <string>/Applications/Raspberry Pi Imager.app</string>
-                </array>
-            </dict>
-            <key>Processor</key>
-            <string>MunkiInstallsItemsCreator</string>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>MunkiPkginfoMerger</string>
-        </dict>
-        <dict>
-            <key>Arguments</key>
-            <dict>
                 <key>pkg_path</key>
-                <string>%RECIPE_CACHE_DIR%/Raspberry Pi Imager-%version%.pkg</string>
+                <string>%pathname%</string>
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
             </dict>
             <key>Processor</key>
             <string>MunkiImporter</string>
-        </dict>
-        <dict>
-            <key>Arguments</key>
-            <dict>
-                <key>path_list</key>
-                <array>
-                    <string>%RECIPE_CACHE_DIR%/Applications</string>
-                </array>
-            </dict>
-            <key>Processor</key>
-            <string>PathDeleter</string>
         </dict>
     </array>
 </dict>


### PR DESCRIPTION
Importing from vendor's dmg requires fewer steps, same result.

Here's the before/after for the pkginfo that gets imported for the newest version of the app:

```diff
--- A/RPiImager-1.9.6.plist
+++ B/RPiImager-1.9.6__1.plist
@@ -27,14 +27,14 @@
 	<string>Raspberry Pi Foundation</string>
 	<key>display_name</key>
 	<string>Raspberry Pi Imaging Utility</string>
-	<key>installed_size</key>
-	<integer>229648</integer>
 	<key>installer_item_hash</key>
+	<string>951e0443cddf3553219d53408ac4ec2d205911c9dfed5e5496862a0fd3296a2f</string>
-	<string>6cbdec868ffa59a535a147eaa30b2519e2053193248a484fda15d7324624b621</string>
 	<key>installer_item_location</key>
+	<string>apps/rpi-imager-1.9.6.dmg</string>
-	<string>apps/Raspberry Pi Imager-1.9.6.pkg</string>
 	<key>installer_item_size</key>
+	<integer>86065</integer>
+	<key>installer_type</key>
+	<string>copy_from_dmg</string>
-	<integer>86150</integer>
 	<key>installs</key>
 	<array>
 		<dict>
@@ -54,27 +54,25 @@
 			<string>CFBundleShortVersionString</string>
 		</dict>
 	</array>
+	<key>items_to_copy</key>
+	<array>
+		<dict>
+			<key>destination_path</key>
+			<string>/Applications</string>
+			<key>source_item</key>
+			<string>Raspberry Pi Imager.app</string>
+		</dict>
+	</array>
 	<key>minimum_os_version</key>
+	<string>10.4.0</string>
-	<string>10.5.0</string>
 	<key>name</key>
 	<string>RPiImager</string>
-	<key>receipts</key>
-	<array>
-		<dict>
-			<key>installed_size</key>
-			<integer>229648</integer>
-			<key>packageid</key>
-			<string>org.raspberrypi.imagingutility</string>
-			<key>version</key>
-			<string>1.9.6</string>
-		</dict>
-	</array>
 	<key>unattended_install</key>
 	<true/>
 	<key>unattended_uninstall</key>
 	<true/>
 	<key>uninstall_method</key>
+	<string>remove_copied_items</string>
-	<string>removepackages</string>
 	<key>uninstallable</key>
 	<true/>
 	<key>version</key>
```

Note that `minimum_os_version` should be 11.0, but that's something that could be kept current in an override. (And wasn't accurate in the pkg version either.)