### PR TITLE
Update app identifier in download recipe

### DIFF
--- a/RPiImager/RPiImager.download.recipe
+++ b/RPiImager/RPiImager.download.recipe
@@ -42,7 +42,7 @@
                 <key>input_path</key>
                 <string>%pathname%/Raspberry Pi Imager.app</string>
                 <key>requirement</key>
-                <string>identifier "org.raspberrypi.imagingutility" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "8RDZTRXE62"</string>
+                <string>identifier "com.raspberrypi.rpi-imager" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "8RDZTRXE62"</string>
             </dict>
         </dict>
     </array>


### PR DESCRIPTION
Hi, @barteklk 

The RaspberryPiImager download recipe is currently failing with 
```
CodeSignatureVerifier: Error: Code signature verification failed. Note that all verifications can be disabled by setting the variable DISABLE_CODE_SIGNATURE_VERIFICATION to a non-empty value.
```

This PR updates the code signature requirement to use the new identifier 'com.raspberrypi.rpi-imager'

https://www.raspberrypi.com/news/a-new-raspberry-pi-imager/

Output from a successful -v run
```
autopkg run -v RPiImager.munki.recipe
Processing RPiImager.munki.recipe...
WARNING: RPiImager.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
GitHubReleasesInfoProvider: Matched regex '.*\.dmg' among asset(s): imager-v2.0.0.exe, Raspberry_Pi_Imager-v2.0.0-cli-aarch64.AppImage, Raspberry_Pi_Imager-v2.0.0-cli-x86_64.AppImage, Raspberry_Pi_Imager-v2.0.0-desktop-aarch64.AppImage, Raspberry_Pi_Imager-v2.0.0-desktop-x86_64.AppImage, Raspberry_Pi_Imager-v2.0.0-embedded-aarch64.AppImage, rpi-imager-cli_2.0.0_arm64.deb, rpi-imager-embedded_2.0.0_arm64.deb, rpi-imager-v2.0.0.dmg, rpi-imager_2.0.0.dsc, rpi-imager_2.0.0.tar.xz, rpi-imager_2.0.0_arm64.buildinfo, rpi-imager_2.0.0_arm64.changes, rpi-imager_2.0.0_arm64.deb
GitHubReleasesInfoProvider: Selected asset 'rpi-imager-v2.0.0.dmg' from release 'v2.0.0: A new Imager'
URLDownloader
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/paul.cossey/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.rpiimager/downloads/rpi-imager-v2.0.0.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.rpiimager/downloads/rpi-imager-v2.0.0.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.E8OikI/Raspberry Pi Imager.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.E8OikI/Raspberry Pi Imager.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.E8OikI/Raspberry Pi Imager.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/RPiImager-v2.0.0.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/rpi-imager-v2.0.0.dmg
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.bnpl.autopkg.munki.rpiimager/receipts/RPiImager.munki-receipt-20251125-213505.plist

The following new items were imported into Munki:
    Name       Version  Catalogs  Pkginfo Path                 Pkg Repo Path               Icon Repo Path  
    ----       -------  --------  ------------                 -------------               --------------  
    RPiImager  v2.0.0   testing   apps/RPiImager-v2.0.0.plist  apps/rpi-imager-v2.0.0.dmg
    ```